### PR TITLE
Initial Query Command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ num-bigint = "0.4.3"
 num-integer = "0.1.45"
 num-rational = "0.4.0"
 num-traits = "0.2.15"
+sexp = "1.1.4"
 
 lalrpop-util = { version = "0.19.7", features = ["lexer"] }
 regex = "1"

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -60,7 +60,11 @@ pub enum Command {
     Extract(Expr),
     // TODO: this could just become an empty query
     Check(Fact),
+<<<<<<< HEAD
     ClearRules,
+=======
+    Query(Vec<Fact>),
+>>>>>>> eeb9f51... initial attempt at adding query command
 }
 
 #[derive(Clone, Debug)]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -60,11 +60,8 @@ pub enum Command {
     Extract(Expr),
     // TODO: this could just become an empty query
     Check(Fact),
-<<<<<<< HEAD
     ClearRules,
-=======
     Query(Vec<Fact>),
->>>>>>> eeb9f51... initial attempt at adding query command
 }
 
 #[derive(Clone, Debug)]

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -43,8 +43,9 @@ Command: Command = {
     "(" "run" <Num> ")" => Command::Run(<>.try_into().unwrap()),
     "(" "extract" <Expr> ")" => Command::Extract(<>),
     "(" "check" <Fact> ")" => Command::Check(<>),
-    "(" "dl" <DLCommand> ")" => <>,
-    "(" "clear-rules" ")" => Command::ClearRules
+    "(" "clear-rules" ")" => Command::ClearRules,
+    "(" "query" <List<Fact>> ")" => Command::Query(<>),
+    "(" "dl" <DLCommand> ")" => <>
 }
 
 DLCommand : Command = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -757,6 +757,20 @@ impl EGraph {
                 self.clear_rules();
                 "Clearing rules.".into()
             }
+            Command::Query(q) => {
+                let q = self
+                    .compile_query(q)
+                    .unwrap_or_else(|_| panic!("Could not compile query"));
+                let mut res = vec![];
+                self.query(&q, |v| {
+                    res.push(sexp::Sexp::List(
+                        v.iter()
+                            .map(|val| sexp::Sexp::Atom(sexp::Atom::S(format!("{}", val))))
+                            .collect(),
+                    ));
+                });
+                format!("{}", sexp::Sexp::List(res))
+            }
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ use thiserror::Error;
 
 use ast::*;
 use std::fmt::Debug;
-use std::fmt::Write;
 use std::hash::Hash;
 
 pub use value::*;
@@ -759,12 +758,11 @@ impl EGraph {
                 "Clearing rules.".into()
             }
             Command::Query(q) => {
-                let mut msg = String::new();
-                write!(msg, "Query: (");
-                for fact in &q {
-                    write!(msg, "{}", fact).unwrap_or_else(|_| panic!("Could not print query"));
-                }
-                write!(msg, ")\n");
+                let qsexp = sexp::Sexp::List(
+                    q.iter()
+                        .map(|fact| sexp::parse(&fact.to_string()).unwrap())
+                        .collect(),
+                );
                 let qcomp = self
                     .compile_query(q)
                     .unwrap_or_else(|_| panic!("Could not compile query"));
@@ -776,14 +774,12 @@ impl EGraph {
                             .collect(),
                     ));
                 });
-                write!(
-                    msg,
-                    "  Bindings: {:?}\n  Results: {}",
+                format!(
+                    "Query: {}\n  Bindings: {:?}\n  Results: {}",
+                    qsexp,
                     qcomp,
                     sexp::Sexp::List(res)
                 )
-                .unwrap_or_else(|_| panic!("Could not print query"));
-                msg
             }
         })
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,10 +1,9 @@
-use std::fmt::Display;
 use num_rational::BigRational;
+use std::fmt::Display;
 
 use crate::{
     ast::{Literal, Symbol},
-    Id,
-    InputType, NumType,
+    Id, InputType, NumType,
 };
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]

--- a/tests/datalog.egg
+++ b/tests/datalog.egg
@@ -9,3 +9,4 @@
 (check (edge 1 2))
 (run 3)
 (check (path 1 3))
+(query ((path x y)))


### PR DESCRIPTION
Minimal version of adding a query command. The current printing is subpar, it is unclear that we want to add sexp as a dependency. To be discussed.
Possibly when printing the query of an eclass id, we also want to extract a term for it rather than print the id. In this case, query may subsume the extract command.
The command `(query ((path x y)))` will print the entire table `path`. 
It is noted in a previous comment that `(query ((path 1 2)))` subsumes the capabilities of `(check (path 1 2))`
It is necessary but not done that we print what element of the sexp corresponds to which pattern variable