### PR TITLE
Clear-rules

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -60,6 +60,7 @@ pub enum Command {
     Extract(Expr),
     // TODO: this could just become an empty query
     Check(Fact),
+    ClearRules,
 }
 
 #[derive(Clone, Debug)]

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -42,7 +42,8 @@ Command: Command = {
     "(" "run" <Num> ")" => Command::Run(<>.try_into().unwrap()),
     "(" "extract" <Expr> ")" => Command::Extract(<>),
     "(" "check" <Fact> ")" => Command::Check(<>),
-    "(" "dl" <DLCommand> ")" => <>
+    "(" "dl" <DLCommand> ")" => <>,
+    "(" "clear-rules" ")" => Command::ClearRules
 }
 
 DLCommand : Command = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,6 +592,10 @@ impl EGraph {
         self.add_rule_with_name(name, rule)
     }
 
+    pub fn clear_rules(&mut self) {
+        self.rules = Default::default();
+    }
+
     pub fn add_rewrite(&mut self, rewrite: ast::Rewrite) -> Result<Symbol, Error> {
         let name = format!("{} -> {}", rewrite.lhs, rewrite.rhs);
         let var = Symbol::from("__rewrite_var");
@@ -686,6 +690,10 @@ impl EGraph {
                 } else {
                     format!("Skipping define {name}")
                 }
+            }
+            Command::ClearRules => {
+                self.clear_rules();
+                "Clearing rules.".into()
             }
         })
     }

--- a/tests/stratified.egg
+++ b/tests/stratified.egg
@@ -1,0 +1,28 @@
+(relation path (i64 i64))
+(relation edge (i64 i64))
+
+(rule ((edge x y))
+      ((path x y)))
+
+
+        
+(assert (edge 1 2))
+(assert (edge 2 3))
+(assert (edge 3 4))
+(check (edge 1 2))
+(run 3)
+(check (path 1 2))
+
+(clear-rules)
+(rule ((path x y) (edge y z))
+      ((path x z)))
+
+(assert (edge 3 8))
+(run 1)
+(check (path 1 3))
+
+
+
+; Should fail
+; (check (path 1 4))
+; (check (path 3 8)) 


### PR DESCRIPTION
Stratification is a useful thing in datalog. A simple mechanism to help enable it is to allow the clearing of current rules while retaining the current database. Alternatives could include `(push-rules)` / `(pop-rules)` or turning on / off named rule sets. This command would be more meaningful when combined with `(saturate)`,  negation and aggregates, but is the first simple step towards those features.