### PR TITLE
Added `=` to datalog syntax

### DIFF
--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -53,6 +53,7 @@ DLCommand : Command = {
 }
 
 DLFact : Fact = {
+    <a:DLExpr> "=" <b:DLExpr> => Fact::Eq(vec![a,b]),
     <DLExpr> => Fact::Fact(<>)
 }
 


### PR DESCRIPTION
Was missing a way to use `=` from Datalog syntax. Perhaps I should enable the chained `=` form in the parser, but I'm not sure how to do this.