### PR TITLE
Bool Primitive

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -9,6 +9,7 @@ pub enum Literal {
     Int(i64),
     Rational(BigRational),
     String(Symbol),
+    Bool(bool),
     Unit,
 }
 
@@ -33,6 +34,7 @@ macro_rules! impl_from {
 }
 
 impl_from!(Int(i64));
+impl_from!(Bool(bool));
 impl_from!(String(Symbol));
 
 impl Literal {
@@ -40,6 +42,7 @@ impl Literal {
         match &self {
             Literal::Int(i) => Value::from(*i),
             Literal::String(s) => Value::from(*s),
+            Literal::Bool(b) => Value::from(*b),
             Literal::Rational(r) => Value::from(r.clone()),
             Literal::Unit => Value(ValueInner::Unit),
         }
@@ -51,6 +54,7 @@ impl Display for Literal {
         match &self {
             Literal::Int(i) => Display::fmt(i, f),
             Literal::String(s) => write!(f, "{s}"),
+            Literal::Bool(b) => write!(f, "{b}"),
             Literal::Rational(r) => write!(f, "{}//{}", r.numer(), r.denom()),
             Literal::Unit => write!(f, "()"),
         }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -85,6 +85,7 @@ pub enum Type {
     Sort(Symbol),
     NumType(NumType),
     String,
+    Bool
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -109,6 +110,7 @@ impl Display for Type {
             Type::Sort(s) => Display::fmt(s, f),
             Type::NumType(t) => Display::fmt(t, f),
             Type::String => write!(f, "String"),
+            Type::Bool => write!(f, "bool"),
             Type::Unit => write!(f, "Unit"),
             Type::Error => write!(f, "Error"),
         }

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -84,6 +84,7 @@ Literal: Literal = {
     <Num> => Literal::Int(<>),
     <numer:Num> "//" <denom:Num> => Literal::Rational(BigRational::new(numer.into(), denom.into())),
     <SymString> => Literal::String(<>),
+    <Bool> => Literal::Bool(<>)
 }
 
 CallExpr: Expr = {
@@ -98,6 +99,7 @@ Variant: Variant = {
 
 Type: Type = { 
     "String" => Type::String,
+    "bool" => Type::Bool,
     <NumType> => Type::NumType(<>),
     <Ident> => Type::Sort(<>),
 }
@@ -105,7 +107,7 @@ Type: Type = {
 NumType: NumType = {
     "i64" => NumType::I64,
     "rational" => NumType::Rational,
-    <s:reserved> =>? lalrpop_error!("{} is reserved.", s)
+    <s:reserved> =>? lalrpop_error!("{} is reserved.", s),
     // "f64" => NumType::F64,
 }
 
@@ -115,6 +117,6 @@ Bool: bool = {
     "false" => false,
 }
 Ident: Symbol = <s:r"[[:alpha:]][\w-]*"> => s.parse().unwrap();
-PrimitiveSymbol: Symbol = <r"[-+*/!=<>]+"> => Symbol::from(<>);
+PrimitiveSymbol: Symbol = <r"[-+*/!=<>&|]+"> => Symbol::from(<>);
 SymString: Symbol = <r#""[^"]*""#> => Symbol::from(<>);
 String: String = <r#""[^"]*""#> => (<>).to_owned();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ fn default_primitives() -> Vec<Primitive> {
     macro_rules! prim {
         (@type ()) => { Type::Unit };
         (@type i64) => { Type::NumType(NumType::I64) };
+        (@type bool) => { Type::Bool };
         (@type BigRational) => { Type::NumType(NumType::Rational) };
         ($name: expr, |$($param:ident : $t:tt),*| -> $output:tt { $body:expr }) => {{
             Primitive::from(SimplePrimitive {
@@ -186,6 +187,10 @@ fn default_primitives() -> Vec<Primitive> {
         prim!("*", |a: i64, b: i64| -> i64 { Some(a * b) }),
         prim!("max", |a: i64, b: i64| -> i64 { Some(a.max(b)) }),
         prim!("min", |a: i64, b: i64| -> i64 { Some(a.min(b)) }),
+        prim!("&&", |a: bool, b: bool| -> bool { Some(a && b) }),
+        prim!("||", |a: bool, b: bool| -> bool { Some(a || b) }),
+        prim!("!", |a: bool| -> bool { Some(!a) }),
+        prim!("==", |a: bool, b: bool| -> bool { Some(a == b) }),
         prim!("<", |a: BigRational, b: BigRational| -> () { (a < b).then(|| ()) }),
         prim!("<=", |a: BigRational, b: BigRational| -> () { (a <= b).then(|| ()) }),
         prim!(">", |a: BigRational, b: BigRational| -> () { (a > b).then(|| ()) }),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -265,6 +265,7 @@ impl<'a> Context<'a> {
             Expr::Lit(lit) => {
                 let t = match lit {
                     Literal::Int(_) => Type::NumType(NumType::I64),
+                    Literal::Bool(_) => Type::Bool,
                     Literal::Rational(_) => Type::NumType(NumType::Rational),
                     Literal::String(_) => Type::String,
                     Literal::Unit => Type::Unit,

--- a/src/value.rs
+++ b/src/value.rs
@@ -40,7 +40,7 @@ impl Value {
 
     pub(crate) fn to_literal(&self) -> Literal {
         match &self.0 {
-            ValueInner::Bool(_) => todo!(),
+            ValueInner::Bool(b) => Literal::Bool(*b),
             ValueInner::Id(_) => panic!("Id isn't a literal"),
             ValueInner::I64(i) => Literal::Int(*i),
             ValueInner::String(s) => Literal::String(*s),
@@ -51,7 +51,7 @@ impl Value {
 
     pub fn get_type(&self) -> Type {
         match &self.0 {
-            ValueInner::Bool(_) => todo!(),
+            ValueInner::Bool(_) => Type::Bool,
             ValueInner::Id(_) => panic!("Does't know the type of id without context"),
             ValueInner::I64(_) => Type::NumType(NumType::I64),
             ValueInner::String(_) => Type::String,

--- a/tests/boolean.egg
+++ b/tests/boolean.egg
@@ -46,8 +46,8 @@
 
 
 ; complementation
-(rewrite (band (bnot a) (a)) (BoolConst false))
-(rewrite (bor (bnot a) (a)) (BoolConst true))
+(rewrite (band (bnot a) a) (BoolConst false))
+(rewrite (bor (bnot a) a) (BoolConst true))
 
 ; de morgan
 (rewrite (bnot (bor a b)) (band (bnot a) (bnot b)))
@@ -57,7 +57,7 @@
 
 (define a (BoolVar "a"))
 (define test1 (band (BoolConst true) a))
-(define test1 (band a a))
+(define test2 (band a a))
 (run 3)
 (extract test1)
 (check (= true (&& true true)))

--- a/tests/boolean.egg
+++ b/tests/boolean.egg
@@ -1,0 +1,67 @@
+(datatype BoolSort
+    (BoolConst bool)
+    (BoolVar String)
+)
+
+; https://en.wikipedia.org/wiki/Boolean_algebra#Laws
+
+(function band (BoolSort BoolSort) BoolSort)
+(function bor (BoolSort BoolSort) BoolSort)
+(function bnot (BoolSort) BoolSort)
+
+; commutativity
+(rewrite (band a b) (band b a))
+(rewrite (bor a b) (bor b a))
+
+; associativity
+(rewrite (band a (band b c)) (band (band a b) c))
+(rewrite (bor a (bor b c)) (bor (bor a b) c))
+(rewrite (band (band a b) c) (band a (band b c)))
+(rewrite (bor (bor a b) c) (bor a (bor b c)))
+
+; idempotence
+(rewrite (band a a) a)
+(rewrite (bor a a) a)
+
+; distributive law
+(rewrite (band a (bor b c)) (bor (band a b) (band a c)))
+(rewrite (bor a (band b c)) (band (bor a b) (bor a c)))
+
+; identity
+(rewrite (bor (BoolConst false) b) b)
+(rewrite (band (BoolConst true) b) b)
+
+; annihilator
+(rewrite (bor (BoolConst true) b) (BoolConst true))
+(rewrite (band (BoolConst false) b) (BoolConst false))
+
+; absorptive law
+(rewrite (band x (bor x y)) x)
+(rewrite (bor x (band x y)) x)
+
+(rewrite (bnot (BoolConst b)) (BolConst (! b)))
+
+; Double negation
+(rewrite (bnot (bnot x)) x)
+
+
+; complementation
+(rewrite (band (bnot a) (a)) (BoolConst false))
+(rewrite (bor (bnot a) (a)) (BoolConst true))
+
+; de morgan
+(rewrite (bnot (bor a b)) (band (bnot a) (bnot b)))
+(rewrite (bnot (band a b)) (bor (bnot a) (bnot b)))
+(rewrite (band (bnot a) (bnot b)) (bnot (bor a b)))
+(rewrite (bor (bnot a) (bnot b)) (bnot (band a b)))
+
+(define a (BoolVar "a"))
+(define test1 (band (BoolConst true) a))
+(define test1 (band a a))
+(run 3)
+(extract test1)
+(check (= true (&& true true)))
+(check (= false (&& false true)))
+(check (= true (|| false true)))
+(check (= true (! false)))
+(check (= false (== true false)))


### PR DESCRIPTION
Simple bool primitive support. This may also be relevant to a theory of bitvectors depending on how it is designed.

Particularly intriguing is the `==` operator. Something very fun about the idea of having both `=` and `==`.

I'm a little concerned about the name clash between `!` used for boolean negation and for datalog negation, but I don't know what to do about it. We don't support datalog negation atm to my knowledge.