### PR TITLE
Make sorts extensible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ indexmap = "1.8"
 hashbrown = "0.12"
 log = "0.4"
 rustc-hash = "1.1"
-symbol_table = { version = "0.2", features = ["global"] }
+# symbol_table = { version = "0.2", features = ["global"] }
+symbol_table = { path = "../symbol_table", features = ["global"] }
 num-bigint = "0.4.3"
 num-integer = "0.1.45"
 num-rational = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ indexmap = "1.8"
 hashbrown = "0.12"
 log = "0.4"
 rustc-hash = "1.1"
+symbol_table = { git = "https://github.com/mwillsey/symbol_table", rev = "acddcf8938d1b4ed2fce048c9d83c30203d404b9", features = ["global"] }
 # symbol_table = { version = "0.2", features = ["global"] }
-symbol_table = { path = "../symbol_table", features = ["global"] }
+# symbol_table = { path = "../symbol_table", features = ["global"] }
 num-bigint = "0.4.3"
 num-integer = "0.1.45"
 num-rational = "0.4.0"

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2,12 +2,9 @@ use crate::*;
 
 use std::fmt::Display;
 
-use num_rational::BigRational;
-
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum Literal {
     Int(i64),
-    Rational(BigRational),
     String(Symbol),
     Unit,
 }
@@ -35,23 +32,11 @@ macro_rules! impl_from {
 impl_from!(Int(i64));
 impl_from!(String(Symbol));
 
-impl Literal {
-    pub fn to_value(&self) -> Value {
-        match &self {
-            Literal::Int(i) => Value::from(*i),
-            Literal::String(s) => Value::from(*s),
-            Literal::Rational(r) => Value::from(r.clone()),
-            Literal::Unit => Value(ValueInner::Unit),
-        }
-    }
-}
-
 impl Display for Literal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
             Literal::Int(i) => Display::fmt(i, f),
             Literal::String(s) => write!(f, "{s}"),
-            Literal::Rational(r) => write!(f, "{}//{}", r.numer(), r.denom()),
             Literal::Unit => write!(f, "()"),
         }
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2,9 +2,9 @@ use std::fmt::Display;
 
 pub use symbol_table::GlobalSymbol as Symbol;
 
-macro_rules! lalrpop_error {
-    ($($x:tt)*) => { Err(::lalrpop_util::ParseError::User { error: format!($($x)*)}) }
-}
+// macro_rules! lalrpop_error {
+//     ($($x:tt)*) => { Err(::lalrpop_util::ParseError::User { error: format!($($x)*)}) }
+// }
 
 use lalrpop_util::lalrpop_mod;
 lalrpop_mod!(
@@ -20,12 +20,6 @@ pub use expr::*;
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Id(usize);
-
-impl Id {
-    pub(crate) fn fake() -> Self {
-        Id(0xbadbeef)
-    }
-}
 
 impl From<usize> for Id {
     fn from(n: usize) -> Self {
@@ -79,65 +73,22 @@ pub struct FunctionDecl {
 #[derive(Clone, Debug)]
 pub struct Variant {
     pub name: Symbol,
-    pub types: Vec<Type>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Type {
-    Error,
-    Unit,
-    Sort(Symbol),
-    NumType(NumType),
-    String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NumType {
-    // F64,
-    I64,
-    Rational,
-}
-
-impl Display for NumType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            NumType::I64 => write!(f, "i64"),
-            NumType::Rational => write!(f, "rational"),
-        }
-    }
-}
-
-impl Display for Type {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Type::Sort(s) => Display::fmt(s, f),
-            Type::NumType(t) => Display::fmt(t, f),
-            Type::String => write!(f, "String"),
-            Type::Unit => write!(f, "Unit"),
-            Type::Error => write!(f, "Error"),
-        }
-    }
-}
-
-impl Type {
-    pub fn is_sort(&self) -> bool {
-        matches!(self, Self::Sort(..))
-    }
+    pub types: Vec<Symbol>,
 }
 
 #[derive(Clone, Debug)]
 pub struct Schema {
-    pub input: Vec<Type>,
-    pub output: Type,
+    pub input: Vec<Symbol>,
+    pub output: Symbol,
 }
 
 impl FunctionDecl {
-    pub fn relation(name: Symbol, input: Vec<Type>) -> Self {
+    pub fn relation(name: Symbol, input: Vec<Symbol>) -> Self {
         Self {
             name,
             schema: Schema {
                 input,
-                output: Type::Unit,
+                output: Symbol::from("Unit"),
             },
             merge: None,
             default: None,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -45,6 +45,7 @@ pub enum Command {
         name: Symbol,
         variants: Vec<Variant>,
     },
+    Sort(Symbol, Symbol, Vec<Expr>),
     Function(FunctionDecl),
     Define(Symbol, Expr),
     Rule(Rule),

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -33,6 +33,7 @@ Comma<T>: Vec<T> = {
 
 Command: Command = {
     "(" "datatype" <name:Ident> <variants:(Variant)*> ")" => Command::Datatype { <> },
+    "(" "sort" <name:Ident> "(" <head:Ident> <tail:(Expr)*> ")" ")" => Command::Sort (<>),
     "(" "function" <name:Ident> <schema:Schema> <merge:(":merge" <Expr>)?> <default:(":default" <Expr>)?> ")" => {
         Command::Function(FunctionDecl { name, schema, merge, default })
     },

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -1,6 +1,5 @@
 use crate::ast::*;
 use crate::Symbol;
-use num_rational::BigRational;
 
 grammar;
 
@@ -86,7 +85,6 @@ Expr: Expr = {
 Literal: Literal = {
     // "(" ")" => Literal::Unit, // shouldn't need unit literals for now
     <Num> => Literal::Int(<>),
-    <numer:Num> "//" <denom:Num> => Literal::Rational(BigRational::new(numer.into(), denom.into())),
     <SymString> => Literal::String(<>),
 }
 
@@ -100,18 +98,7 @@ Variant: Variant = {
     "(" <name:Ident> <types:(Type)*> ")" => Variant { <> },
 }
 
-Type: Type = { 
-    "String" => Type::String,
-    <NumType> => Type::NumType(<>),
-    <Ident> => Type::Sort(<>),
-}
-
-NumType: NumType = {
-    "i64" => NumType::I64,
-    "rational" => NumType::Rational,
-    <s:reserved> =>? lalrpop_error!("{} is reserved.", s)
-    // "f64" => NumType::F64,
-}
+Type: Symbol = <Ident>;
 
 Num: i64 = <s:r"(-)?[0-9]+"> => s.parse().unwrap();
 Bool: bool = {

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -107,21 +107,22 @@ impl<'a> Extractor<'a> {
 
             for &sym in &self.ctors {
                 let func = &self.egraph.functions[&sym];
-                assert!(func.schema.output.is_eq_sort());
-                for (inputs, output) in &func.nodes {
-                    if let Some(new_cost) = self.node_total_cost(&func.schema.input, inputs) {
-                        let make_new_pair = || (new_cost, Node { sym, inputs });
+                if func.schema.output.is_eq_sort() {
+                    for (inputs, output) in &func.nodes {
+                        if let Some(new_cost) = self.node_total_cost(&func.schema.input, inputs) {
+                            let make_new_pair = || (new_cost, Node { sym, inputs });
 
-                        let id = Id::from(output.bits as usize);
-                        match self.costs.entry(id) {
-                            Entry::Vacant(e) => {
-                                did_something = true;
-                                e.insert(make_new_pair());
-                            }
-                            Entry::Occupied(mut e) => {
-                                if new_cost < e.get().0 {
+                            let id = Id::from(output.bits as usize);
+                            match self.costs.entry(id) {
+                                Entry::Vacant(e) => {
                                     did_something = true;
                                     e.insert(make_new_pair());
+                                }
+                                Entry::Occupied(mut e) => {
+                                    if new_cost < e.get().0 {
+                                        did_something = true;
+                                        e.insert(make_new_pair());
+                                    }
                                 }
                             }
                         }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,8 +1,8 @@
 use hashbrown::hash_map::Entry;
 
-use crate::ast::{Symbol, Type};
+use crate::ast::Symbol;
 use crate::util::HashMap;
-use crate::{EGraph, Expr, Id, Value};
+use crate::{ArcSort, EGraph, Expr, Id, Value};
 
 type Cost = usize;
 
@@ -19,19 +19,29 @@ struct Extractor<'a> {
 }
 
 impl EGraph {
-    pub fn extract(&mut self, id: Id) -> (Cost, Expr) {
-        Extractor::new(self).find_best(id)
+    pub fn value_to_id(&self, value: Value) -> Option<(Symbol, Id)> {
+        if let Some(sort) = self.sorts.get(&value.tag) {
+            if sort.is_eq_sort() {
+                let id = Id::from(value.bits as usize);
+                return Some((sort.name(), self.find(id)));
+            }
+        }
+        None
     }
 
-    pub fn extract_variants(&mut self, id: Id, limit: usize) -> Vec<Expr> {
-        let id = self.find(id);
-        let output_value = &Value::from(id);
+    pub fn extract(&mut self, value: Value) -> (Cost, Expr) {
+        Extractor::new(self).find_best(value)
+    }
+
+    pub fn extract_variants(&mut self, value: Value, limit: usize) -> Vec<Expr> {
+        let (tag, id) = self.value_to_id(value).unwrap();
+        let output_value = &Value::from_id(tag, id);
         let ext = &Extractor::new(self);
         ext.ctors
             .iter()
             .flat_map(|&sym| {
                 let func = &self.functions[&sym];
-                assert!(func.decl.schema.output.is_sort());
+                assert!(func.schema.output.is_eq_sort());
                 func.nodes.iter().filter_map(move |(inputs, output)| {
                     (output == output_value).then(|| {
                         let node = Node { sym, inputs };
@@ -52,9 +62,9 @@ impl<'a> Extractor<'a> {
             ctors: vec![],
         };
 
-        for ctors in egraph.sorts.values() {
-            extractor.ctors.extend(ctors.iter().copied())
-        }
+        // HACK
+        // just consider all functions constructors for now...
+        extractor.ctors.extend(egraph.functions.keys().cloned());
 
         log::debug!("Extracting from ctors: {:?}", extractor.ctors);
         extractor.find_costs();
@@ -62,34 +72,27 @@ impl<'a> Extractor<'a> {
     }
 
     fn expr_from_node(&self, node: &Node) -> Expr {
-        let mut children = vec![];
-        for (ty, value) in self.egraph.functions[&node.sym]
-            .decl
-            .schema
-            .input
-            .iter()
-            .zip(node.inputs)
-        {
-            if ty.is_sort() {
-                children.push(self.find_best(Id::from(value.clone())).1)
-            } else {
-                children.push(Expr::Lit(value.to_literal()))
-            }
-        }
+        let children = node.inputs.iter().map(|&value| self.find_best(value).1);
         Expr::call(node.sym, children)
     }
 
-    fn find_best(&self, id: Id) -> (Cost, Expr) {
-        let id = self.egraph.find(id);
-        let (cost, node) = &self.costs[&id];
-        (*cost, self.expr_from_node(node))
+    fn find_best(&self, value: Value) -> (Cost, Expr) {
+        let sort = self.egraph.sorts.get(&value.tag).unwrap();
+        if sort.is_eq_sort() {
+            let id = self.egraph.find(Id::from(value.bits as usize));
+            let (cost, node) = &self.costs[&id];
+            (*cost, self.expr_from_node(node))
+        } else {
+            (0, sort.make_expr(value))
+        }
     }
 
-    fn node_total_cost(&self, types: &[Type], children: &[Value]) -> Option<Cost> {
+    fn node_total_cost(&self, types: &[ArcSort], children: &[Value]) -> Option<Cost> {
         let mut cost = 1;
         for (ty, value) in types.iter().zip(children) {
-            cost += if ty.is_sort() {
-                self.costs.get(&Id::from(value.clone()))?.0
+            cost += if ty.is_eq_sort() {
+                // TODO costs should probably map values?
+                self.costs.get(&Id::from(value.bits as usize))?.0
             } else {
                 0
             }
@@ -104,11 +107,13 @@ impl<'a> Extractor<'a> {
 
             for &sym in &self.ctors {
                 let func = &self.egraph.functions[&sym];
-                assert!(func.decl.schema.output.is_sort());
+                assert!(func.schema.output.is_eq_sort());
                 for (inputs, output) in &func.nodes {
-                    if let Some(new_cost) = self.node_total_cost(&func.decl.schema.input, inputs) {
+                    if let Some(new_cost) = self.node_total_cost(&func.schema.input, inputs) {
                         let make_new_pair = || (new_cost, Node { sym, inputs });
-                        match self.costs.entry(Id::from(output.clone())) {
+
+                        let id = Id::from(output.bits as usize);
+                        match self.costs.entry(id) {
                             Entry::Vacant(e) => {
                                 did_something = true;
                                 e.insert(make_new_pair());

--- a/src/gj.rs
+++ b/src/gj.rs
@@ -202,7 +202,6 @@ impl EGraph {
     ) -> CompiledQuery {
         let mut extra = vec![];
         let mut vars: IndexMap<Symbol, VarInfo> = Default::default();
-        //     types.keys().map(|sym| (*sym, Default::default())).collect();
         for (i, atom) in atoms.iter().enumerate() {
             match atom {
                 Atom::Func(_, _) => {

--- a/src/gj.rs
+++ b/src/gj.rs
@@ -71,7 +71,7 @@ impl<'b> Context<'b> {
                 let rs: Vec<&'b Trie> = trie_indices.iter().map(|&j| self.tries[j]).collect();
 
                 for val in intersection {
-                    self.tuple[*idx] = val.clone();
+                    self.tuple[*idx] = val;
 
                     for (r, &j) in rs.iter().zip(trie_indices) {
                         self.tries[j] = match r.0.get(&val) {
@@ -95,9 +95,9 @@ impl<'b> Context<'b> {
                     values.push(match arg {
                         AtomTerm::Var(v) => {
                             let i = self.query.vars.get_index_of(v).unwrap();
-                            self.tuple[i].clone()
+                            self.tuple[i]
                         }
-                        AtomTerm::Value(val) => val.clone(),
+                        AtomTerm::Value(val) => *val,
                     })
                 }
 
@@ -168,7 +168,7 @@ impl<'b> Trie<'b> {
         for i in shuffle {
             trie = trie
                 .0
-                .entry(tuple[*i].clone())
+                .entry(tuple[*i])
                 .or_insert_with(|| bump.alloc(Trie::default()));
         }
     }
@@ -198,7 +198,7 @@ impl EGraph {
     pub(crate) fn compile_gj_query(
         &self,
         atoms: Vec<Atom>,
-        _types: HashMap<Symbol, Type>,
+        _types: HashMap<Symbol, ArcSort>,
     ) -> CompiledQuery {
         let mut extra = vec![];
         let mut vars: IndexMap<Symbol, VarInfo> = Default::default();
@@ -303,7 +303,7 @@ impl EGraph {
 
             for (i, t) in args.iter().enumerate() {
                 match t {
-                    AtomTerm::Value(val) => constraints.push(Constraint::Const(i, val.clone())),
+                    AtomTerm::Value(val) => constraints.push(Constraint::Const(i, *val)),
                     AtomTerm::Var(_v) => {
                         if let Some(j) = args[..i].iter().position(|t2| t == t2) {
                             constraints.push(Constraint::Eq(j, i));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,16 +38,10 @@ pub struct Function {
     updates: usize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct ResolvedSchema {
     input: Vec<ArcSort>,
     output: ArcSort,
-}
-
-impl Debug for ResolvedSchema {
-    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        todo!()
-    }
 }
 
 impl Function {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,30 @@
 pub mod ast;
 mod extract;
 mod gj;
+pub mod sort;
 mod typecheck;
 mod unionfind;
 mod util;
 mod value;
 
 use hashbrown::hash_map::Entry;
+use sort::*;
 use thiserror::Error;
 
 use ast::*;
+
 use std::fmt::Write;
 use std::hash::Hash;
 use std::ops::Deref;
 use std::{fmt::Debug, sync::Arc};
 use typecheck::{AtomTerm, Bindings};
 
+type ArcSort = Arc<dyn Sort>;
+
 pub use value::*;
 
 use gj::*;
-use num_rational::BigRational;
+
 use unionfind::*;
 use util::*;
 
@@ -28,33 +33,38 @@ use crate::typecheck::TypeError;
 #[derive(Clone)]
 pub struct Function {
     decl: FunctionDecl,
+    schema: ResolvedSchema,
     nodes: HashMap<Vec<Value>, Value>,
     updates: usize,
 }
 
-impl Function {
-    pub fn new(decl: FunctionDecl) -> Self {
-        Self {
-            decl,
-            nodes: Default::default(),
-            updates: 0,
-        }
-    }
+#[derive(Clone)]
+struct ResolvedSchema {
+    input: Vec<ArcSort>,
+    output: ArcSort,
+}
 
+impl Debug for ResolvedSchema {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
+}
+
+impl Function {
     pub fn rebuild(&mut self, uf: &mut UnionFind) -> usize {
         // FIXME this doesn't compute updates properly
         let n_unions = uf.n_unions();
         let old_nodes = std::mem::take(&mut self.nodes);
         for (mut args, value) in old_nodes {
-            for (a, ty) in args.iter_mut().zip(&self.decl.schema.input) {
-                if ty.is_sort() {
-                    *a = uf.find_mut_value(a.clone())
+            for (a, ty) in args.iter_mut().zip(&self.schema.input) {
+                if ty.is_eq_sort() {
+                    *a = uf.find_mut_value(*a)
                 }
             }
-            let _new_value = if self.decl.schema.output.is_sort() {
+            let _new_value = if self.schema.output.is_eq_sort() {
                 self.nodes
                     .entry(args)
-                    .and_modify(|value2| *value2 = uf.union_values(value.clone(), value2.clone()))
+                    .and_modify(|value2| *value2 = uf.union_values(value, *value2))
                     .or_insert_with(|| uf.find_mut_value(value))
             } else {
                 self.nodes
@@ -71,7 +81,7 @@ pub type Subst = IndexMap<Symbol, Value>;
 
 pub trait PrimitiveLike {
     fn name(&self) -> Symbol;
-    fn accept(&self, types: &[Type]) -> Option<Type>;
+    fn accept(&self, types: &[&dyn Sort]) -> Option<ArcSort>;
     fn apply(&self, values: &[Value]) -> Option<Value>;
 }
 
@@ -117,8 +127,8 @@ impl<T: PrimitiveLike + 'static> From<T> for Primitive {
 
 pub struct SimplePrimitive {
     name: Symbol,
-    input: Vec<Type>,
-    output: Type,
+    input: Vec<ArcSort>,
+    output: ArcSort,
     f: fn(&[Value]) -> Option<Value>,
 }
 
@@ -126,92 +136,26 @@ impl PrimitiveLike for SimplePrimitive {
     fn name(&self) -> Symbol {
         self.name
     }
-    fn accept(&self, types: &[Type]) -> Option<Type> {
-        (types == self.input).then(|| self.output.clone())
+    fn accept(&self, types: &[&dyn Sort]) -> Option<ArcSort> {
+        if self.input.len() != types.len() {
+            return None;
+        }
+        // TODO can we use a better notion of equality than just names?
+        self.input
+            .iter()
+            .zip(types)
+            .all(|(a, b)| a.name() == b.name())
+            .then(|| self.output.clone())
     }
     fn apply(&self, values: &[Value]) -> Option<Value> {
         (self.f)(values)
     }
 }
 
-pub struct NotEqualPrimitive;
-
-impl PrimitiveLike for NotEqualPrimitive {
-    fn name(&self) -> Symbol {
-        "!=".into()
-    }
-
-    fn accept(&self, types: &[Type]) -> Option<Type> {
-        match types {
-            [a, b] if a == b => Some(Type::Unit),
-            _ => None,
-        }
-    }
-
-    fn apply(&self, values: &[Value]) -> Option<Value> {
-        (values[0] != values[1]).then(|| Value(ValueInner::Unit))
-    }
-}
-
-fn default_primitives() -> Vec<Primitive> {
-    macro_rules! prim {
-        (@type ()) => { Type::Unit };
-        (@type i64) => { Type::NumType(NumType::I64) };
-        (@type BigRational) => { Type::NumType(NumType::Rational) };
-        ($name: expr, |$($param:ident : $t:tt),*| -> $output:tt { $body:expr }) => {{
-            Primitive::from(SimplePrimitive {
-                name: Symbol::from($name),
-                input: vec![$(prim!(@type $t)),*],
-                output: prim!(@type $output),
-                f: |values| {
-                    let mut values = values.iter();
-                    $(
-                        let $param: $t = values.next().unwrap().clone().into();
-                    )*
-                    let opt: Option<_> = $body;
-                    opt.map(Value::from)
-                }
-            })
-        }};
-    }
-
-    #[rustfmt::skip]
-    let vec = vec![
-        NotEqualPrimitive.into(),
-        prim!("<", |a: i64, b: i64| -> () { (a < b).then(|| ()) }),
-        prim!("<=", |a: i64, b: i64| -> () { (a <= b).then(|| ()) }),
-        prim!(">", |a: i64, b: i64| -> () { (a > b).then(|| ()) }),
-        prim!(">=", |a: i64, b: i64| -> () { (a >= b).then(|| ()) }),
-        prim!("+", |a: i64, b: i64| -> i64 { Some(a + b) }),
-        prim!("-", |a: i64, b: i64| -> i64 { Some(a - b) }),
-        prim!("*", |a: i64, b: i64| -> i64 { Some(a * b) }),
-        prim!("/", |a: i64, b: i64| -> i64 { (b != 0).then(|| a / b ) }),
-        prim!("%", |a: i64, b: i64| -> i64 { (b != 0).then(|| a % b ) }),
-        prim!("&", |a: i64, b: i64| -> i64 { Some(a & b) }),
-        prim!("|", |a: i64, b: i64| -> i64 { Some(a | b) }),
-        prim!("^", |a: i64, b: i64| -> i64 { Some(a ^ b) }),
-        prim!(">>", |a: i64, b: i64| -> i64 { Some(a >> b) }),
-        prim!("<<", |a: i64, b: i64| -> i64 { Some(a << b) }),
-        prim!("not-i64", |a: i64| -> i64 { Some(!a) }),
-        prim!("max", |a: i64, b: i64| -> i64 { Some(a.max(b)) }),
-        prim!("min", |a: i64, b: i64| -> i64 { Some(a.min(b)) }),
-        prim!("<", |a: BigRational, b: BigRational| -> () { (a < b).then(|| ()) }),
-        prim!("<=", |a: BigRational, b: BigRational| -> () { (a <= b).then(|| ()) }),
-        prim!(">", |a: BigRational, b: BigRational| -> () { (a > b).then(|| ()) }),
-        prim!(">=", |a: BigRational, b: BigRational| -> () { (a >= b).then(|| ()) }),
-        prim!("+", |a: BigRational, b: BigRational| -> BigRational { Some(a + b) }),
-        prim!("-", |a: BigRational, b: BigRational| -> BigRational { Some(a - b) }),
-        prim!("*", |a: BigRational, b: BigRational| -> BigRational { Some(a * b) }),
-        prim!("max", |a: BigRational, b: BigRational| -> BigRational { Some(a.max(b)) }),
-        prim!("min", |a: BigRational, b: BigRational| -> BigRational { Some(a.min(b)) }),
-    ];
-    vec
-}
-
 #[derive(Clone)]
 pub struct EGraph {
     unionfind: UnionFind,
-    sorts: HashMap<Symbol, Vec<Symbol>>,
+    sorts: HashMap<Symbol, Arc<dyn Sort>>,
     primitives: HashMap<Symbol, Vec<Primitive>>,
     functions: HashMap<Symbol, Function>,
     rules: HashMap<Symbol, Rule>,
@@ -235,9 +179,10 @@ impl Default for EGraph {
             globals: Default::default(),
             primitives: Default::default(),
         };
-        for prim in default_primitives() {
-            egraph.add_primitive(prim);
-        }
+        egraph.add_sort(UnitSort::new("Unit".into()));
+        egraph.add_sort(StringSort::new("String".into()));
+        egraph.add_sort(I64Sort::new("i64".into()));
+        egraph.add_sort(RationalSort::new("Rational".into()));
         egraph
     }
 }
@@ -247,6 +192,29 @@ impl Default for EGraph {
 pub struct NotFoundError(Expr);
 
 impl EGraph {
+    pub fn add_sort<S: Sort + 'static>(&mut self, sort: S) {
+        match self.sorts.entry(sort.name()) {
+            Entry::Occupied(_) => panic!(),
+            Entry::Vacant(e) => {
+                let sort = Arc::new(sort);
+                e.insert(sort.clone());
+                sort.register_primitives(self);
+            }
+        };
+    }
+
+    fn get_sort<S: Sort + Send + Sync>(&self) -> Arc<S> {
+        for sort in self.sorts.values() {
+            let sort = sort.clone().as_arc_any();
+            if let Ok(sort) = Arc::downcast(sort) {
+                return sort;
+            }
+        }
+        // TODO handle if multiple match?
+        // could handle by type id??
+        panic!("Failed to lookup sort: {}", std::any::type_name::<S>());
+    }
+
     fn add_primitive(&mut self, prim: Primitive) {
         self.primitives.entry(prim.name()).or_default().push(prim);
     }
@@ -263,16 +231,16 @@ impl EGraph {
                 for input in inputs {
                     assert_eq!(
                         input,
-                        &self.bad_find_value(input.clone()),
-                        "{name}({inputs:?}) = {output}\n{:?}",
-                        function.decl.schema,
+                        &self.bad_find_value(*input),
+                        "{name}({inputs:?}) = {output:?}\n{:?}",
+                        function.schema,
                     )
                 }
                 assert_eq!(
                     output,
-                    &self.bad_find_value(output.clone()),
-                    "{name}({inputs:?}) = {output}\n{:?}",
-                    function.decl.schema,
+                    &self.bad_find_value(*output),
+                    "{name}({inputs:?}) = {output:?}\n{:?}",
+                    function.schema,
                 )
             }
         }
@@ -323,16 +291,17 @@ impl EGraph {
                         .functions
                         .get_mut(f)
                         .ok_or_else(|| NotFoundError(e.clone()))?;
-                    let old_value = function.nodes.insert(values.clone(), value.clone());
+                    let old_value = function.nodes.insert(values.clone(), value);
 
                     if let Some(old_value) = old_value {
                         if value != old_value {
-                            match (function.decl.merge.as_ref(), &function.decl.schema.output) {
-                                (None, Type::Unit) => (),
-                                (None, Type::Sort(_)) => {
+                            let out = &function.schema.output;
+                            match function.decl.merge.as_ref() {
+                                None if out.name().as_str() == "Unit" => (),
+                                None if out.is_eq_sort() => {
                                     self.unionfind.union_values(old_value, value);
                                 }
-                                (Some(expr), _) => {
+                                Some(expr) => {
                                     let mut ctx = Subst::default();
                                     ctx.insert("old".into(), old_value);
                                     ctx.insert("new".into(), value);
@@ -344,7 +313,7 @@ impl EGraph {
                                         .nodes
                                         .insert(values, new_value);
                                 }
-                                _ => panic!("invalid merge function"),
+                                _ => panic!("invalid merge"),
                             }
                         }
                     }
@@ -372,12 +341,12 @@ impl EGraph {
                     if &values[0] != v {
                         // the check failed, so print out some useful info
                         for value in &values {
-                            if let Value(ValueInner::Id(id)) = value {
-                                let best = self.extract(*id).1;
+                            if let Some((_tag, id)) = self.value_to_id(*value) {
+                                let best = self.extract(*value).1;
                                 println!("{}: {}", id, best);
                             }
                         }
-                        return Err(Error::CheckError(values[0].clone(), v.clone()));
+                        return Err(Error::CheckError(values[0], *v));
                     }
                 }
             }
@@ -391,7 +360,7 @@ impl EGraph {
                         .collect::<Result<_, _>>()?;
                     if let Some(f) = self.functions.get_mut(sym) {
                         // FIXME We don't have a unit value
-                        assert_eq!(f.decl.schema.output, Type::Unit);
+                        assert_eq!(f.schema.output.name().as_str(), "Unit");
                         f.nodes
                             .get(&values)
                             .ok_or_else(|| NotFoundError(expr.clone()))?;
@@ -399,7 +368,7 @@ impl EGraph {
                         // HACK
                         // we didn't typecheck so we don't know which prim to call
                         let val = self.eval_expr(ctx, expr)?;
-                        assert_eq!(val, ().into());
+                        assert_eq!(val, Value::unit());
                     } else {
                         return Err(Error::TypeError(TypeError::Unbound(*sym)));
                     }
@@ -440,30 +409,35 @@ impl EGraph {
         match self.sorts.entry(name) {
             Entry::Occupied(_) => Err(Error::SortAlreadyBound(name)),
             Entry::Vacant(e) => {
-                e.insert(vec![]);
+                e.insert(Arc::new(EqSort { name }));
                 Ok(())
             }
         }
     }
 
     pub fn declare_function(&mut self, decl: &FunctionDecl) -> Result<(), Error> {
-        for ty in &decl.schema.input {
-            if let Type::Sort(sort) = ty {
-                if !self.sorts.contains_key(sort) {
-                    return Err(TypeError::UndefinedSort(*sort).into());
-                }
-            }
+        let mut input = Vec::with_capacity(decl.schema.input.len());
+        for s in &decl.schema.input {
+            input.push(match self.sorts.get(s) {
+                Some(sort) => sort.clone(),
+                None => return Err(Error::TypeError(TypeError::Unbound(*s))),
+            })
         }
 
-        if let Type::Sort(sort) = &decl.schema.output {
-            if !self.sorts.contains_key(sort) {
-                return Err(TypeError::UndefinedSort(*sort).into());
-            }
-        }
+        let output = match self.sorts.get(&decl.schema.output) {
+            Some(sort) => sort.clone(),
+            None => return Err(Error::TypeError(TypeError::Unbound(decl.schema.output))),
+        };
 
-        let old = self
-            .functions
-            .insert(decl.name, Function::new(decl.clone()));
+        let function = Function {
+            decl: decl.clone(),
+            schema: ResolvedSchema { input, output },
+            nodes: HashMap::default(),
+            updates: 0,
+            // TODO figure out merge and default here
+        };
+
+        let old = self.functions.insert(decl.name, function);
         if old.is_some() {
             return Err(TypeError::FunctionAlreadyBound(decl.name).into());
         }
@@ -474,7 +448,7 @@ impl EGraph {
     pub fn declare_constructor(
         &mut self,
         name: impl Into<Symbol>,
-        types: Vec<Type>,
+        types: Vec<Symbol>,
         sort: impl Into<Symbol>,
     ) -> Result<(), Error> {
         let name = name.into();
@@ -483,15 +457,23 @@ impl EGraph {
             name,
             schema: Schema {
                 input: types,
-                output: Type::Sort(sort),
+                output: sort,
             },
             merge: None,
             default: None,
         })?;
-        if let Some(ctors) = self.sorts.get_mut(&sort) {
-            ctors.push(name);
-        }
+        // if let Some(ctors) = self.sorts.get_mut(&sort) {
+        //     ctors.push(name);
+        // }
         Ok(())
+    }
+
+    pub fn eval_lit(&self, lit: &Literal) -> Value {
+        match lit {
+            Literal::Int(i) => i.store(&*self.get_sort()).unwrap(),
+            Literal::String(s) => s.store(&*self.get_sort()).unwrap(),
+            Literal::Unit => ().store(&*self.get_sort()).unwrap(),
+        }
     }
 
     // this must be &mut because it'll call "make_set",
@@ -504,7 +486,7 @@ impl EGraph {
                 .or_else(|| self.globals.get(var))
                 .cloned()
                 .unwrap_or_else(|| panic!("Couldn't find variable '{var}'"))),
-            Expr::Lit(lit) => Ok(lit.to_value()),
+            Expr::Lit(lit) => Ok(self.eval_lit(lit)),
             Expr::Call(op, args) => {
                 let values: Vec<Value> = args
                     .iter()
@@ -512,23 +494,25 @@ impl EGraph {
                     .collect::<Result<_, _>>()?;
                 if let Some(function) = self.functions.get_mut(op) {
                     if let Some(value) = function.nodes.get(&values) {
-                        Ok(value.clone())
+                        Ok(*value)
                     } else {
-                        match (function.decl.default.as_ref(), &function.decl.schema.output) {
-                            (None, Type::Unit) => {
-                                function.nodes.insert(values, Value(ValueInner::Unit));
-                                Ok(Value(ValueInner::Unit))
+                        let out = &function.schema.output;
+                        match function.decl.default.as_ref() {
+                            None if out.name() == "Unit".into() => {
+                                function.nodes.insert(values, Value::unit());
+                                Ok(Value::unit())
                             }
-                            (None, Type::Sort(_)) => {
+                            None if out.is_eq_sort() => {
                                 let id = self.unionfind.make_set();
-                                function.nodes.insert(values, Value(ValueInner::Id(id)));
-                                Ok(Value(ValueInner::Id(id)))
+                                let value = Value::from_id(out.name(), id);
+                                function.nodes.insert(values, value);
+                                Ok(value)
                             }
-                            (Some(default), _) => {
+                            Some(default) => {
                                 let default = default.clone(); // break the borrow
                                 let value = self.eval_expr(ctx, &default)?;
                                 let function = self.functions.get_mut(op).unwrap();
-                                function.nodes.insert(values, value.clone());
+                                function.nodes.insert(values, value);
                                 Ok(value)
                             }
                             _ => panic!("invalid default"),
@@ -538,7 +522,10 @@ impl EGraph {
                     let mut res = None;
                     for prim in prims.iter() {
                         // HACK
-                        let types = values.iter().map(|v| v.get_type()).collect::<Vec<_>>();
+                        let types = values
+                            .iter()
+                            .map(|v| &*self.sorts[&v.tag])
+                            .collect::<Vec<_>>();
                         if prim.accept(&types).is_some() {
                             if res.is_none() {
                                 res = prim.apply(&values);
@@ -574,7 +561,7 @@ impl EGraph {
         for (name, r) in &self.functions {
             log::debug!("{name}:");
             for (args, val) in &r.nodes {
-                log::debug!("  {args:?} = {val}");
+                log::debug!("  {args:?} = {val:?}");
             }
         }
     }
@@ -596,9 +583,9 @@ impl EGraph {
                                         let i = rule.query.vars.get_index_of(sym).unwrap_or_else(
                                             || panic!("Couldn't find variable '{sym}'"),
                                         );
-                                        values[i].clone()
+                                        values[i]
                                     }
-                                    AtomTerm::Value(val) => val.clone(),
+                                    AtomTerm::Value(val) => *val,
                                 };
                                 (*k, val)
                             })
@@ -669,7 +656,7 @@ impl EGraph {
             // FIXME canonicalize, do we need to with rebuilding?
             // ids.extend(children.iter().map(|id| self.find(value)));
             ids.extend(children.iter().cloned());
-            ids.push(value.clone());
+            ids.push(*value);
             cb(&ids);
         }
     }
@@ -709,12 +696,11 @@ impl EGraph {
                     // TODO typecheck
                     let value = self.eval_closed_expr(&e)?;
                     self.rebuild();
-                    let id = Id::from(value);
-                    log::info!("Extracting {e} at {id}");
-                    let (cost, expr) = self.extract(id);
+                    log::info!("Extracting {e} at {value:?}");
+                    let (cost, expr) = self.extract(value);
                     let mut msg = format!("Extracted with cost {cost}: {expr}");
                     if variants > 0 {
-                        let exprs = self.extract_variants(id, variants);
+                        let exprs = self.extract_variants(value, variants);
                         let line = "\n    ";
                         let varnts = ListDisplay(&exprs, line);
                         write!(msg, "\nVariants of {expr}:{line}{varnts}").unwrap();
@@ -803,9 +789,10 @@ impl EGraph {
 
     // this is bad because we shouldn't inspect values like this, we should use type information
     fn bad_find_value(&self, value: Value) -> Value {
-        match &value.0 {
-            ValueInner::Id(id) => self.unionfind.find(*id).into(),
-            _ => value,
+        if let Some((tag, id)) = self.value_to_id(value) {
+            Value::from_id(tag, id)
+        } else {
+            value
         }
     }
 
@@ -828,7 +815,7 @@ pub enum Error {
     TypeError(#[from] TypeError),
     #[error("Errors:\n{}", ListDisplay(.0, "\n"))]
     TypeErrors(Vec<TypeError>),
-    #[error("Check failed: {0} != {1}")]
+    #[error("Check failed: {0:?} != {1:?}")]
     CheckError(Value, Value),
     #[error("Sort {0} already declared.")]
     SortAlreadyBound(Symbol),

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -1,0 +1,67 @@
+use crate::ast::Literal;
+
+use super::*;
+
+#[derive(Debug)]
+pub struct I64Sort {
+    name: Symbol,
+}
+
+impl I64Sort {
+    pub fn new(name: Symbol) -> Self {
+        Self { name }
+    }
+}
+
+impl Sort for I64Sort {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
+        self
+    }
+
+    #[rustfmt::skip]
+    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
+        type Opt<T=()> = Option<T>;
+
+        add_primitives!(eg, "+" = |a: i64, b: i64| -> i64 { a + b });
+        add_primitives!(eg, "-" = |a: i64, b: i64| -> i64 { a - b });
+        add_primitives!(eg, "*" = |a: i64, b: i64| -> i64 { a * b });
+        add_primitives!(eg, "/" = |a: i64, b: i64| -> Opt<i64> { (b != 0).then(|| a / b) });
+        add_primitives!(eg, "%" = |a: i64, b: i64| -> Opt<i64> { (b != 0).then(|| a % b) });
+
+        add_primitives!(eg, "&" = |a: i64, b: i64| -> i64 { a & b });
+        add_primitives!(eg, "|" = |a: i64, b: i64| -> i64 { a | b });
+        add_primitives!(eg, "^" = |a: i64, b: i64| -> i64 { a ^ b });
+        add_primitives!(eg, "<<" = |a: i64, b: i64| -> Opt<i64> { b.try_into().ok().and_then(|b| a.checked_shl(b)) });
+        add_primitives!(eg, ">>" = |a: i64, b: i64| -> Opt<i64> { b.try_into().ok().and_then(|b| a.checked_shr(b)) });
+        add_primitives!(eg, "not-i64" = |a: i64| -> i64 { !a });
+
+        add_primitives!(eg, "<" = |a: i64, b: i64| -> Opt { (a < b).then(|| ()) }); 
+        add_primitives!(eg, ">" = |a: i64, b: i64| -> Opt { (a > b).then(|| ()) }); 
+    }
+
+    fn make_expr(&self, value: Value) -> Expr {
+        assert!(value.tag == self.name());
+        Expr::Lit(Literal::Int(value.bits as _))
+    }
+}
+
+impl IntoSort for i64 {
+    type Sort = I64Sort;
+    fn store(self, sort: &Self::Sort) -> Option<Value> {
+        Some(Value {
+            tag: sort.name,
+            bits: self as u64,
+        })
+    }
+}
+
+impl FromSort for i64 {
+    type Sort = I64Sort;
+    fn load(_sort: &Self::Sort, value: &Value) -> Self {
+        value.bits as Self
+    }
+}

--- a/src/sort/macros.rs
+++ b/src/sort/macros.rs
@@ -1,0 +1,81 @@
+#[macro_export]
+macro_rules! to_tt {
+    ($tt:tt, $callback:ident) => {
+        $callback!($tt)
+    };
+}
+
+#[macro_export]
+macro_rules! unpack {
+    (& $t:ident) => {
+        $t
+    };
+    ($t:ident) => {
+        $t
+    };
+}
+
+#[macro_export]
+macro_rules! add_primitives {
+    ($egraph:expr, $($rest:tt)*) => {
+         add_primitives!(@doubled $egraph, $($rest)*, $($rest)*)
+    };
+    (@doubled $egraph:expr,
+        // { $($t:ident),* }, // TODO unused
+        // $name:literal = |$($param:ident : $($r:tt)? $t:ident),*| -> $ret:ty { $body:expr }
+        $name:literal = |$($param:ident : $param_t:ty),*| -> $ret:ty { $body:expr },
+        $name2:literal = |$($param2:ident : $(&)? $base_param_t:ident),*| -> $ret2:ty { $body2:expr }
+    ) => {{
+        let egraph: &mut _ = $egraph;
+        #[allow(unused_imports, non_snake_case)]
+        {
+            use $crate::{*, sort::*};
+
+            struct MyPrim {$(
+                // $param: to_tt!($t, unpack),
+                // $t: Arc<<$t as IntoSort>::Sort>,
+                $param: Arc<<$base_param_t as FromSort>::Sort>,
+            )*
+                __out: Arc<<$ret as IntoSort>::Sort>,
+            }
+
+            impl $crate::PrimitiveLike for MyPrim {
+                fn name(&self) -> $crate::Symbol {
+                    $name.into()
+                }
+
+                fn accept(&self, types: &[&dyn Sort]) -> Option<ArcSort> {
+                    let mut types = types.iter();
+                    $(
+                        if self.$param.name() != types.next()?.name() {
+                            return None;
+                        }
+                    )*
+                    if types.next().is_some() {
+                        None
+                    } else {
+                        Some(self.__out.clone())
+                    }
+                }
+
+                fn apply(&self, values: &[Value]) -> Option<Value> {
+                    if let [$($param),*] = values {
+                        $(let $param: $param_t = <$param_t as FromSort>::load(&self.$param, $param);)*
+                        print!("{}( ", $name);
+                        $( print!("{}={:?}, ", stringify!($param), $param); )*
+                        let result: $ret = $body;
+                        println!(") = {result:?}");
+                        result.store(&self.__out)
+                    } else {
+                        panic!()
+                    }
+                }
+            }
+
+            egraph.add_primitive($crate::Primitive::from(MyPrim {
+                $( $param: egraph.get_sort::<<$base_param_t as IntoSort>::Sort>(), )*
+                __out: egraph.get_sort::<<$ret as IntoSort>::Sort>(),
+            }))
+        }
+    }};
+}

--- a/src/sort/macros.rs
+++ b/src/sort/macros.rs
@@ -17,14 +17,12 @@ macro_rules! unpack {
 
 #[macro_export]
 macro_rules! add_primitives {
-    ($egraph:expr, $($rest:tt)*) => {
-         add_primitives!(@doubled $egraph, $($rest)*, $($rest)*)
-    };
-    (@doubled $egraph:expr,
-        // { $($t:ident),* }, // TODO unused
-        // $name:literal = |$($param:ident : $($r:tt)? $t:ident),*| -> $ret:ty { $body:expr }
-        $name:literal = |$($param:ident : $param_t:ty),*| -> $ret:ty { $body:expr },
-        $name2:literal = |$($param2:ident : $(&)? $base_param_t:ident),*| -> $ret2:ty { $body2:expr }
+    // ($egraph:expr, $($rest:tt)*) => {
+    //      add_primitives!(@doubled $egraph, $($rest)*, $($rest)*)
+    // };
+    ($egraph:expr,
+        $name:literal = |$($param:ident : $param_t:ty),*| -> $ret:ty { $body:expr }
+        // $name2:literal = |$($param2:ident : $(&)? $base_param_t:ident),*| -> $ret2:ty { $body2:expr }
     ) => {{
         let egraph: &mut _ = $egraph;
         #[allow(unused_imports, non_snake_case)]
@@ -32,9 +30,7 @@ macro_rules! add_primitives {
             use $crate::{*, sort::*};
 
             struct MyPrim {$(
-                // $param: to_tt!($t, unpack),
-                // $t: Arc<<$t as IntoSort>::Sort>,
-                $param: Arc<<$base_param_t as FromSort>::Sort>,
+                $param: Arc<<$param_t as FromSort>::Sort>,
             )*
                 __out: Arc<<$ret as IntoSort>::Sort>,
             }
@@ -73,7 +69,7 @@ macro_rules! add_primitives {
             }
 
             egraph.add_primitive($crate::Primitive::from(MyPrim {
-                $( $param: egraph.get_sort::<<$base_param_t as IntoSort>::Sort>(), )*
+                $( $param: egraph.get_sort::<<$param_t as IntoSort>::Sort>(), )*
                 __out: egraph.get_sort::<<$ret as IntoSort>::Sort>(),
             }))
         }

--- a/src/sort/map.rs
+++ b/src/sort/map.rs
@@ -1,0 +1,168 @@
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use super::*;
+
+type ValueMap = BTreeMap<Value, Value>;
+
+#[derive(Debug)]
+pub struct MapSort {
+    name: Symbol,
+    key: ArcSort,
+    value: ArcSort,
+    maps: Mutex<IndexSet<ValueMap>>,
+}
+
+impl MapSort {
+    fn kv_names(&self) -> (Symbol, Symbol) {
+        (self.key.name(), self.value.name())
+    }
+
+    pub fn make_sort(egraph: &mut EGraph, name: Symbol, args: &[Expr]) -> Result<ArcSort, Error> {
+        if let [Expr::Var(k), Expr::Var(v)] = args {
+            let k = egraph.sorts.get(k).ok_or(TypeError::UndefinedSort(*k))?;
+            let v = egraph.sorts.get(v).ok_or(TypeError::UndefinedSort(*v))?;
+            Ok(Arc::new(Self {
+                name,
+                key: k.clone(),
+                value: v.clone(),
+                maps: Default::default(),
+            }))
+        } else {
+            panic!()
+        }
+    }
+}
+
+impl Sort for MapSort {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
+        self
+    }
+
+    fn register_primitives(self: Arc<Self>, egraph: &mut EGraph) {
+        egraph.add_primitive(Ctor {
+            name: "empty".into(),
+            map: self.clone(),
+        });
+        egraph.add_primitive(Insert {
+            name: "insert".into(),
+            map: self.clone(),
+        });
+        egraph.add_primitive(Get {
+            name: "get".into(),
+            map: self,
+        });
+    }
+
+    fn make_expr(&self, value: Value) -> Expr {
+        let map = ValueMap::load(self, &value);
+        let mut expr = Expr::call("empty", []);
+        for (k, v) in map.iter().rev() {
+            let k = self.key.make_expr(*k);
+            let v = self.value.make_expr(*v);
+            expr = Expr::call("insert", [expr, k, v])
+        }
+        expr
+    }
+}
+
+impl IntoSort for ValueMap {
+    type Sort = MapSort;
+    fn store(self, sort: &Self::Sort) -> Option<Value> {
+        let mut maps = sort.maps.lock().unwrap();
+        let (i, _) = maps.insert_full(self);
+        Some(Value {
+            tag: sort.name,
+            bits: i as u64,
+        })
+    }
+}
+
+impl FromSort for ValueMap {
+    type Sort = MapSort;
+    fn load(sort: &Self::Sort, value: &Value) -> Self {
+        let maps = sort.maps.lock().unwrap();
+        maps.get_index(value.bits as usize).unwrap().clone()
+    }
+}
+
+struct Ctor {
+    name: Symbol,
+    map: Arc<MapSort>,
+}
+
+impl PrimitiveLike for Ctor {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[&dyn Sort]) -> Option<ArcSort> {
+        match types {
+            [] => Some(self.map.clone()),
+            _ => None,
+        }
+    }
+
+    fn apply(&self, values: &[Value]) -> Option<Value> {
+        assert!(values.is_empty());
+        ValueMap::default().store(&self.map)
+    }
+}
+
+struct Insert {
+    name: Symbol,
+    map: Arc<MapSort>,
+}
+
+impl PrimitiveLike for Insert {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[&dyn Sort]) -> Option<ArcSort> {
+        match types {
+            [map, key, value]
+                if (map.name(), (key.name(), value.name()))
+                    == (self.map.name, self.map.kv_names()) =>
+            {
+                Some(self.map.clone())
+            }
+            _ => None,
+        }
+    }
+
+    fn apply(&self, values: &[Value]) -> Option<Value> {
+        let mut map = ValueMap::load(&self.map, &values[0]);
+        map.insert(values[1], values[2]);
+        map.store(&self.map)
+    }
+}
+
+struct Get {
+    name: Symbol,
+    map: Arc<MapSort>,
+}
+
+impl PrimitiveLike for Get {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[&dyn Sort]) -> Option<ArcSort> {
+        match types {
+            [map, key] if (map.name(), key.name()) == (self.map.name, self.map.key.name()) => {
+                Some(self.map.value.clone())
+            }
+            _ => None,
+        }
+    }
+
+    fn apply(&self, values: &[Value]) -> Option<Value> {
+        let map = ValueMap::load(&self.map, &values[0]);
+        map.get(&values[1]).copied()
+    }
+}

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -59,20 +59,7 @@ pub trait FromSort: Sized {
 
 pub trait IntoSort: Sized {
     type Sort: Sort;
-    // fn load(sort: &Self::Sort, value: &Value) -> Self;
     fn store(self, sort: &Self::Sort) -> Option<Value>;
-    // fn into_option(self) -> Option<Self> {
-    //     Some(self)
-    // }
-    // fn name() -> &'static str {
-    //     Self::Sort::name()
-    // }
-    // fn get_type() -> Symbol {
-    //     Self::Sort::get_type()
-    // }
-    // fn is_type(t: &Symbol) -> bool {
-    //     Self::Sort::is_type(t)
-    // }
 }
 
 impl<T: IntoSort> IntoSort for Option<T> {

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -1,0 +1,84 @@
+#[macro_use]
+mod macros;
+use std::fmt::Debug;
+use std::{any::Any, sync::Arc};
+
+mod rational;
+pub use rational::*;
+mod string;
+pub use string::*;
+mod unit;
+pub use unit::*;
+mod i64;
+pub use self::i64::*;
+
+use crate::ast::Expr;
+use crate::{ast::Symbol, EGraph, Value};
+
+pub trait Sort: Any + Send + Sync + Debug {
+    fn name(&self) -> Symbol;
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static>;
+    fn is_eq_sort(&self) -> bool {
+        false
+    }
+
+    fn register_primitives(self: Arc<Self>, egraph: &mut EGraph) {
+        let _ = egraph;
+    }
+
+    fn make_expr(&self, value: Value) -> Expr;
+}
+
+#[derive(Debug)]
+pub struct EqSort {
+    pub name: Symbol,
+}
+
+impl Sort for EqSort {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
+        self
+    }
+
+    fn is_eq_sort(&self) -> bool {
+        true
+    }
+
+    fn make_expr(&self, _value: Value) -> Expr {
+        unimplemented!("No make_expr for EqSort {}", self.name)
+    }
+}
+
+pub trait FromSort: Sized {
+    type Sort: Sort;
+    fn load(sort: &Self::Sort, value: &Value) -> Self;
+}
+
+pub trait IntoSort: Sized {
+    type Sort: Sort;
+    // fn load(sort: &Self::Sort, value: &Value) -> Self;
+    fn store(self, sort: &Self::Sort) -> Option<Value>;
+    // fn into_option(self) -> Option<Self> {
+    //     Some(self)
+    // }
+    // fn name() -> &'static str {
+    //     Self::Sort::name()
+    // }
+    // fn get_type() -> Symbol {
+    //     Self::Sort::get_type()
+    // }
+    // fn is_type(t: &Symbol) -> bool {
+    //     Self::Sort::is_type(t)
+    // }
+}
+
+impl<T: IntoSort> IntoSort for Option<T> {
+    type Sort = T::Sort;
+
+    fn store(self, sort: &Self::Sort) -> Option<Value> {
+        self?.store(sort)
+    }
+}

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -11,9 +11,10 @@ mod unit;
 pub use unit::*;
 mod i64;
 pub use self::i64::*;
+mod map;
+pub use map::*;
 
-use crate::ast::Expr;
-use crate::{ast::Symbol, EGraph, Value};
+use crate::*;
 
 pub trait Sort: Any + Send + Sync + Debug {
     fn name(&self) -> Symbol;
@@ -69,3 +70,5 @@ impl<T: IntoSort> IntoSort for Option<T> {
         self?.store(sort)
     }
 }
+
+pub type PreSort = fn(egraph: &mut EGraph, name: Symbol, params: &[Expr]) -> Result<ArcSort, Error>;

--- a/src/sort/rational.rs
+++ b/src/sort/rational.rs
@@ -1,7 +1,7 @@
 use num_rational::BigRational;
 use std::sync::Mutex;
 
-use crate::util::IndexSet;
+use crate::{ast::Literal, util::IndexSet};
 
 use super::*;
 
@@ -44,36 +44,18 @@ impl Sort for RationalSort {
     }
     fn make_expr(&self, value: Value) -> Expr {
         assert!(value.tag == self.name());
-        // Expr::Lit(Literal::Int(value.bits as _))
-        todo!()
+        let rat = BigRational::load(self, &value);
+        let numer = i64::try_from(rat.numer()).unwrap();
+        let denom = i64::try_from(rat.denom()).unwrap();
+        Expr::call(
+            "rational",
+            vec![
+                Expr::Lit(Literal::Int(numer)),
+                Expr::Lit(Literal::Int(denom)),
+            ],
+        )
     }
 }
-
-// impl<'a> TypedSort<'a, BigRational> for RationalSort {
-//     fn load(&'a self, value: &Value) -> BigRational {
-//         let i = value.bits as usize;
-//         self.rats.lock().unwrap().get_index(i).unwrap().clone()
-//     }
-//     fn store(&'a self, t: BigRational) -> Value {
-//         let i = self.rats.lock().unwrap().insert(t);
-//         Value {
-//             tag: self.name,
-//             bits: i as u64,
-//         }
-//     }
-// }
-
-// impl TypedSort<'_> for BigRational {
-//     type Load = BigRational;
-//     type Store = BigRational;
-
-//     fn load(&self) -> BigRational {
-//         self.clone()
-//     }
-//     fn store(&self) -> BigRational {
-//         self.clone()
-//     }
-// }
 
 impl FromSort for BigRational {
     type Sort = RationalSort;
@@ -93,18 +75,3 @@ impl IntoSort for BigRational {
         })
     }
 }
-
-// impl<'a> TypedSort<'a, &'a BigRational> for RationalSort {
-//     fn load(&'a self, value: &Value) -> &'a BigRational {
-//         let i = value.bits as usize;
-//         self.rats.lock().unwrap().get_index(i).unwrap()
-//     }
-
-//     fn store(&self, t: &BigRational) -> Value {
-//         let i = self.rats.lock().unwrap().insert(t.clone());
-//         Value {
-//             tag: self.name,
-//             bits: i as u64,
-//         }
-//     }
-// }

--- a/src/sort/rational.rs
+++ b/src/sort/rational.rs
@@ -1,0 +1,110 @@
+use num_rational::BigRational;
+use std::sync::Mutex;
+
+use crate::util::IndexSet;
+
+use super::*;
+
+#[derive(Debug)]
+pub struct RationalSort {
+    name: Symbol,
+    rats: Mutex<IndexSet<BigRational>>,
+}
+
+impl RationalSort {
+    pub fn new(name: Symbol) -> Self {
+        Self {
+            name,
+            rats: Default::default(),
+        }
+    }
+}
+
+impl Sort for RationalSort {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
+        self
+    }
+
+    #[rustfmt::skip]
+    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
+        type R = BigRational;
+        // TODO we can't have primitives take borrows just yet, since it
+        // requires returning a reference to the locked sort
+        add_primitives!(eg, "+" = |a: R, b: R| -> R { a + b });
+        add_primitives!(eg, "-" = |a: R, b: R| -> R { a - b });
+        add_primitives!(eg, "*" = |a: R, b: R| -> R { a * b });
+        add_primitives!(eg, "/" = |a: R, b: R| -> R { a / b }); // TODO option
+        add_primitives!(eg, "min" = |a: R, b: R| -> R { a.min(b) });
+        add_primitives!(eg, "max" = |a: R, b: R| -> R { a.max(b) });
+        add_primitives!(eg, "rational" = |a: i64, b: i64| -> R { R::new(a.into(), b.into()) });
+    }
+    fn make_expr(&self, value: Value) -> Expr {
+        assert!(value.tag == self.name());
+        // Expr::Lit(Literal::Int(value.bits as _))
+        todo!()
+    }
+}
+
+// impl<'a> TypedSort<'a, BigRational> for RationalSort {
+//     fn load(&'a self, value: &Value) -> BigRational {
+//         let i = value.bits as usize;
+//         self.rats.lock().unwrap().get_index(i).unwrap().clone()
+//     }
+//     fn store(&'a self, t: BigRational) -> Value {
+//         let i = self.rats.lock().unwrap().insert(t);
+//         Value {
+//             tag: self.name,
+//             bits: i as u64,
+//         }
+//     }
+// }
+
+// impl TypedSort<'_> for BigRational {
+//     type Load = BigRational;
+//     type Store = BigRational;
+
+//     fn load(&self) -> BigRational {
+//         self.clone()
+//     }
+//     fn store(&self) -> BigRational {
+//         self.clone()
+//     }
+// }
+
+impl FromSort for BigRational {
+    type Sort = RationalSort;
+    fn load(sort: &Self::Sort, value: &Value) -> Self {
+        let i = value.bits as usize;
+        sort.rats.lock().unwrap().get_index(i).unwrap().clone()
+    }
+}
+
+impl IntoSort for BigRational {
+    type Sort = RationalSort;
+    fn store(self, sort: &Self::Sort) -> Option<Value> {
+        let (i, _) = sort.rats.lock().unwrap().insert_full(self);
+        Some(Value {
+            tag: sort.name,
+            bits: i as u64,
+        })
+    }
+}
+
+// impl<'a> TypedSort<'a, &'a BigRational> for RationalSort {
+//     fn load(&'a self, value: &Value) -> &'a BigRational {
+//         let i = value.bits as usize;
+//         self.rats.lock().unwrap().get_index(i).unwrap()
+//     }
+
+//     fn store(&self, t: &BigRational) -> Value {
+//         let i = self.rats.lock().unwrap().insert(t.clone());
+//         Value {
+//             tag: self.name,
+//             bits: i as u64,
+//         }
+//     }
+// }

--- a/src/sort/string.rs
+++ b/src/sort/string.rs
@@ -1,0 +1,51 @@
+use std::num::NonZeroU32;
+
+use crate::ast::Literal;
+
+use super::*;
+
+#[derive(Debug)]
+pub struct StringSort {
+    name: Symbol,
+}
+
+impl StringSort {
+    pub fn new(name: Symbol) -> Self {
+        Self { name }
+    }
+}
+
+impl Sort for StringSort {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
+        self
+    }
+
+    fn make_expr(&self, value: Value) -> Expr {
+        assert!(value.tag == self.name);
+        let sym = Symbol::from(NonZeroU32::new(value.bits as _).unwrap());
+        Expr::Lit(Literal::String(sym))
+    }
+}
+
+// TODO could use a local symbol table
+
+impl IntoSort for Symbol {
+    type Sort = StringSort;
+    fn store(self, sort: &Self::Sort) -> Option<Value> {
+        Some(Value {
+            tag: sort.name,
+            bits: NonZeroU32::from(self).get() as _,
+        })
+    }
+}
+
+impl FromSort for Symbol {
+    type Sort = StringSort;
+    fn load(_sort: &Self::Sort, value: &Value) -> Self {
+        NonZeroU32::new(value.bits as u32).unwrap().into()
+    }
+}

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -1,0 +1,61 @@
+use super::*;
+use crate::{ast::Literal, ArcSort, PrimitiveLike};
+
+#[derive(Debug)]
+pub struct UnitSort {
+    name: Symbol,
+}
+
+impl UnitSort {
+    pub fn new(name: Symbol) -> Self {
+        Self { name }
+    }
+}
+
+impl Sort for UnitSort {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
+        self
+    }
+
+    fn register_primitives(self: Arc<Self>, egraph: &mut EGraph) {
+        egraph.add_primitive(NotEqualPrimitive { unit: self }.into())
+    }
+
+    fn make_expr(&self, value: Value) -> Expr {
+        assert_eq!(value.tag, self.name);
+        Expr::Lit(Literal::Unit)
+    }
+}
+
+impl IntoSort for () {
+    type Sort = UnitSort;
+
+    fn store(self, _sort: &Self::Sort) -> Option<Value> {
+        Some(Value::unit())
+    }
+}
+
+pub struct NotEqualPrimitive {
+    unit: ArcSort,
+}
+
+impl PrimitiveLike for NotEqualPrimitive {
+    fn name(&self) -> Symbol {
+        "!=".into()
+    }
+
+    fn accept(&self, types: &[&dyn Sort]) -> Option<ArcSort> {
+        match types {
+            [a, b] if a.name() == b.name() => Some(self.unit.clone()),
+            _ => None,
+        }
+    }
+
+    fn apply(&self, values: &[Value]) -> Option<Value> {
+        (values[0] != values[1]).then(Value::unit)
+    }
+}

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -22,7 +22,7 @@ impl Sort for UnitSort {
     }
 
     fn register_primitives(self: Arc<Self>, egraph: &mut EGraph) {
-        egraph.add_primitive(NotEqualPrimitive { unit: self }.into())
+        egraph.add_primitive(NotEqualPrimitive { unit: self })
     }
 
     fn make_expr(&self, value: Value) -> Expr {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -7,12 +7,13 @@ pub enum TypeError {
     #[error("Arity mismatch, expected {expected} args: {expr}")]
     Arity { expr: Expr, expected: usize },
     #[error(
-        "Type mismatch: expr = {expr}, expected = {expected}, actual = {actual}, reason: {reason}"
+        "Type mismatch: expr = {expr}, expected = {}, actual = {}, reason: {reason}", 
+        .expected.name(), .actual.name(),
     )]
     Mismatch {
         expr: Expr,
-        expected: Type,
-        actual: Type,
+        expected: ArcSort,
+        actual: ArcSort,
         reason: String,
     },
     #[error("Tried to unify too many literals: {}", ListDisplay(.0, "\n"))]
@@ -28,12 +29,13 @@ pub enum TypeError {
     #[error("Failed to infer a type for: {0}")]
     InferenceFailure(Expr),
     #[error("No matching primitive for: ({op} {})", ListDisplay(.inputs, " "))]
-    NoMatchingPrimitive { op: Symbol, inputs: Vec<Type> },
+    NoMatchingPrimitive { op: Symbol, inputs: Vec<Symbol> },
 }
 
 pub struct Context<'a> {
     pub egraph: &'a EGraph,
-    pub types: HashMap<Symbol, Type>,
+    pub types: HashMap<Symbol, ArcSort>,
+    unit: ArcSort,
     errors: Vec<TypeError>,
     unionfind: UnionFind,
     nodes: HashMap<ENode, Id>,
@@ -75,6 +77,7 @@ impl<'a> Context<'a> {
     pub fn new(egraph: &'a EGraph) -> Self {
         Self {
             egraph,
+            unit: egraph.sorts[&"Unit".into()].clone(),
             types: HashMap::default(),
             errors: Vec::default(),
             unionfind: UnionFind::default(),
@@ -104,7 +107,7 @@ impl<'a> Context<'a> {
             debug_assert_eq!(id, self.unionfind.find(id));
             match node {
                 ENode::Literal(lit) => {
-                    let old = leaves.insert(id, AtomTerm::Value(lit.to_value()));
+                    let old = leaves.insert(id, AtomTerm::Value(self.egraph.eval_lit(lit)));
                     if let Some(AtomTerm::Value(old)) = old {
                         panic!("Duplicate literal: {:?} {:?}", old, lit);
                     }
@@ -177,7 +180,7 @@ impl<'a> Context<'a> {
         match fact {
             Fact::Eq(exprs) => {
                 let mut later = vec![];
-                let mut ty: Option<Type> = None;
+                let mut ty: Option<ArcSort> = None;
                 let mut ids = Vec::with_capacity(exprs.len());
                 for expr in exprs {
                     match (expr, &ty) {
@@ -188,8 +191,8 @@ impl<'a> Context<'a> {
                         // so we'll try again later when we can check its type
                         (Expr::Var(v), None) if !self.types.contains_key(v) => later.push(expr),
                         (_, None) => match self.infer_query_expr(expr) {
-                            (_, Type::Error) => (),
-                            (id, t) => {
+                            (_, None) => (),
+                            (id, Some(t)) => {
                                 ty = Some(t);
                                 ids.push(id);
                             }
@@ -198,7 +201,6 @@ impl<'a> Context<'a> {
                 }
 
                 if let Some(ty) = ty {
-                    assert_ne!(ty, Type::Error);
                     for e in later {
                         ids.push(self.check_query_expr(e, ty.clone()));
                     }
@@ -211,17 +213,17 @@ impl<'a> Context<'a> {
                 ids.into_iter().reduce(|a, b| self.unionfind.union(a, b));
             }
             Fact::Fact(e) => {
-                self.check_query_expr(e, Type::Unit);
+                self.check_query_expr(e, self.unit.clone());
             }
         }
     }
 
-    fn check_query_expr(&mut self, expr: &'a Expr, expected: Type) -> Id {
-        assert_ne!(expected, Type::Error);
+    fn check_query_expr(&mut self, expr: &'a Expr, expected: ArcSort) -> Id {
         if let Expr::Var(sym) = expr {
             match self.types.entry(*sym) {
                 Entry::Occupied(ty) => {
-                    if ty.get() != &expected {
+                    // TODO name comparison??
+                    if ty.get().name() != expected.name() {
                         self.errors.push(TypeError::Mismatch {
                             expr: expr.clone(),
                             expected,
@@ -238,75 +240,81 @@ impl<'a> Context<'a> {
             self.add_node(ENode::Var(*sym))
         } else {
             let (id, actual) = self.infer_query_expr(expr);
-            if actual != expected {
-                self.errors.push(TypeError::Mismatch {
-                    expr: expr.clone(),
-                    expected,
-                    actual,
-                    reason: "mismatch".into(),
-                })
+            if let Some(actual) = actual {
+                if actual.name() != expected.name() {
+                    self.errors.push(TypeError::Mismatch {
+                        expr: expr.clone(),
+                        expected,
+                        actual,
+                        reason: "mismatch".into(),
+                    })
+                }
             }
             id
         }
     }
 
-    fn infer_query_expr(&mut self, expr: &'a Expr) -> (Id, Type) {
+    fn infer_query_expr(&mut self, expr: &'a Expr) -> (Id, Option<ArcSort>) {
         match expr {
             // TODO handle global variables
             Expr::Var(sym) => {
                 let ty = if let Some(ty) = self.types.get(sym) {
-                    ty.clone()
+                    Some(ty.clone())
                 } else {
                     self.errors.push(TypeError::Unbound(*sym));
-                    Type::Error
+                    None
                 };
                 (self.add_node(ENode::Var(*sym)), ty)
             }
             Expr::Lit(lit) => {
                 let t = match lit {
-                    Literal::Int(_) => Type::NumType(NumType::I64),
-                    Literal::Rational(_) => Type::NumType(NumType::Rational),
-                    Literal::String(_) => Type::String,
-                    Literal::Unit => Type::Unit,
+                    Literal::Int(_) => self.egraph.sorts.get(&"i64".into()),
+                    Literal::String(_) => todo!(),
+                    Literal::Unit => self.egraph.sorts.get(&"Unit".into()),
                 };
-                (self.add_node(ENode::Literal(lit.clone())), t)
+                (self.add_node(ENode::Literal(lit.clone())), t.cloned())
             }
             Expr::Call(sym, args) => {
                 if let Some(f) = self.egraph.functions.get(sym) {
-                    if f.decl.schema.input.len() != args.len() {
+                    if f.schema.input.len() != args.len() {
                         self.errors.push(TypeError::Arity {
                             expr: expr.clone(),
-                            expected: f.decl.schema.input.len(),
+                            expected: f.schema.input.len(),
                         });
                     }
 
                     let ids: Vec<Id> = args
                         .iter()
-                        .zip(&f.decl.schema.input)
+                        .zip(&f.schema.input)
                         .map(|(arg, ty)| self.check_query_expr(arg, ty.clone()))
                         .collect();
-                    let t = f.decl.schema.output.clone();
-                    (self.add_node(ENode::Func(*sym, ids)), t)
+                    let t = f.schema.output.clone();
+                    (self.add_node(ENode::Func(*sym, ids)), Some(t))
                 } else if let Some(prims) = self.egraph.primitives.get(sym) {
-                    let (ids, arg_tys): (Vec<Id>, Vec<Type>) =
+                    let (ids, arg_tys): (Vec<Id>, Vec<Option<ArcSort>>) =
                         args.iter().map(|arg| self.infer_query_expr(arg)).unzip();
-                    for prim in prims {
-                        if let Some(output_type) = prim.accept(&arg_tys) {
-                            let id = self.add_node(ENode::Prim(prim.clone(), ids));
-                            return (id, output_type);
+
+                    if let Some(arg_tys) = arg_tys
+                        .iter()
+                        .map(|opta| opta.as_deref())
+                        .collect::<Option<Vec<&dyn Sort>>>()
+                    {
+                        for prim in prims {
+                            if let Some(output_type) = prim.accept(&arg_tys) {
+                                let id = self.add_node(ENode::Prim(prim.clone(), ids));
+                                return (id, Some(output_type));
+                            }
                         }
-                    }
-                    // No need to push this error if the argument types are wrong
-                    if !arg_tys.contains(&Type::Error) {
                         self.errors.push(TypeError::NoMatchingPrimitive {
                             op: *sym,
-                            inputs: arg_tys,
+                            inputs: arg_tys.iter().map(|t| t.name()).collect(),
                         });
                     }
-                    (self.unionfind.make_set(), Type::Error)
+
+                    (self.unionfind.make_set(), None)
                 } else {
                     self.errors.push(TypeError::Unbound(*sym));
-                    (self.unionfind.make_set(), Type::Error)
+                    (self.unionfind.make_set(), None)
                 }
             }
         }

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -36,12 +36,18 @@ impl UnionFind<()> {
         self.make_set_with(())
     }
 
-    pub fn find_mut_value(&mut self, value: Value) -> Value {
-        self.find_mut(value.into()).into()
+    pub fn find_mut_value(&mut self, mut value: Value) -> Value {
+        // HACK this is not safe
+        let id = Id::from(value.bits as usize);
+        value.bits = usize::from(self.find_mut(id)) as u64;
+        value
     }
 
     pub fn union_values(&mut self, value1: Value, value2: Value) -> Value {
-        self.union(value1.into(), value2.into()).into()
+        let id1 = Id::from(value1.bits as usize);
+        let id2 = Id::from(value2.bits as usize);
+        assert_eq!(value1.tag, value2.tag);
+        Value::from_id(value1.tag, self.union(id1, id2))
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,10 +1,6 @@
+use std::num::NonZeroU32;
 
-use std::{num::NonZeroU32};
-
-use crate::{
-    ast::{Symbol},
-    Id,
-};
+use crate::{ast::Symbol, Id};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 // FIXME this shouldn't be pub
@@ -36,72 +32,6 @@ impl Value {
     }
 }
 
-// impl Display for Value {
-//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//         match &self.0 {
-//             ValueInner::Bool(b) => b.fmt(f),
-//             ValueInner::Id(id) => id.fmt(f),
-//             ValueInner::I64(i) => i.fmt(f),
-//             ValueInner::String(s) => write!(f, "\"{s}\""),
-//             ValueInner::Rational(r) => r.fmt(f),
-//             ValueInner::Unit => write!(f, "()"),
-//         }
-//     }
-// }
-
-// impl Value {
-//     pub fn fake() -> Self {
-//         Value(ValueInner::Id(Id::fake()))
-//     }
-
-//     pub(crate) fn to_literal(&self) -> Literal {
-//         match &self.0 {
-//             ValueInner::Bool(_) => todo!(),
-//             ValueInner::Id(_) => panic!("Id isn't a literal"),
-//             ValueInner::I64(i) => Literal::Int(*i),
-//             ValueInner::String(s) => Literal::String(*s),
-//             ValueInner::Rational(r) => Literal::Rational(r.clone()),
-//             ValueInner::Unit => Literal::Unit,
-//         }
-//     }
-
-//     pub fn get_type(&self) -> Type {
-//         match &self.0 {
-//             ValueInner::Bool(_) => todo!(),
-//             ValueInner::Id(_) => panic!("Does't know the type of id without context"),
-//             ValueInner::I64(_) => Type::NumType(NumType::I64),
-//             ValueInner::String(_) => Type::String,
-//             ValueInner::Rational(_) => Type::NumType(NumType::Rational),
-//             ValueInner::Unit => Type::Unit,
-//         }
-//     }
-// }
-
-// macro_rules! impl_from {
-//     ($ctor:ident($t:ty)) => {
-//         impl From<Value> for $t {
-//             fn from(value: Value) -> Self {
-//                 match value.0 {
-//                     ValueInner::$ctor(t) => t,
-//                     _ => panic!("Expected {}, got {value:?}", stringify!($ctor)),
-//                 }
-//             }
-//         }
-
-//         impl From<$t> for Value {
-//             fn from(t: $t) -> Self {
-//                 Value(ValueInner::$ctor(t))
-//             }
-//         }
-//     };
-// }
-
-// impl From<()> for Value {
-//     fn from(_: ()) -> Self {
-//         Value(ValueInner::Unit)
-//     }
-// }
-
 impl From<i64> for Value {
     fn from(i: i64) -> Self {
         Self {
@@ -119,9 +49,3 @@ impl From<Symbol> for Value {
         }
     }
 }
-
-// impl_from!(Id(Id));
-// impl_from!(I64(i64));
-// impl_from!(Bool(bool));
-// impl_from!(String(Symbol));
-// impl_from!(Rational(BigRational));

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,93 +1,127 @@
-use num_rational::BigRational;
-use std::fmt::Display;
+
+use std::{num::NonZeroU32};
 
 use crate::{
-    ast::{Literal, Symbol},
-    Id, NumType, Type,
+    ast::{Symbol},
+    Id,
 };
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 // FIXME this shouldn't be pub
-pub struct Value(pub ValueInner);
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
-pub enum ValueInner {
-    Unit,
-    Bool(bool),
-    Id(Id),
-    I64(i64),
-    Rational(BigRational),
-    String(Symbol),
-}
-
-impl Display for Value {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.0 {
-            ValueInner::Bool(b) => b.fmt(f),
-            ValueInner::Id(id) => id.fmt(f),
-            ValueInner::I64(i) => i.fmt(f),
-            ValueInner::String(s) => write!(f, "\"{s}\""),
-            ValueInner::Rational(r) => r.fmt(f),
-            ValueInner::Unit => write!(f, "()"),
-        }
-    }
+pub struct Value {
+    pub tag: Symbol,
+    pub bits: u64,
 }
 
 impl Value {
+    pub fn unit() -> Self {
+        Value {
+            tag: Symbol::new("Unit"),
+            bits: 0,
+        }
+    }
+
     pub fn fake() -> Self {
-        Value(ValueInner::Id(Id::fake()))
-    }
-
-    pub(crate) fn to_literal(&self) -> Literal {
-        match &self.0 {
-            ValueInner::Bool(_) => todo!(),
-            ValueInner::Id(_) => panic!("Id isn't a literal"),
-            ValueInner::I64(i) => Literal::Int(*i),
-            ValueInner::String(s) => Literal::String(*s),
-            ValueInner::Rational(r) => Literal::Rational(r.clone()),
-            ValueInner::Unit => Literal::Unit,
+        Value {
+            tag: Symbol::new("__bogus__"),
+            bits: 1234567890,
         }
     }
 
-    pub fn get_type(&self) -> Type {
-        match &self.0 {
-            ValueInner::Bool(_) => todo!(),
-            ValueInner::Id(_) => panic!("Does't know the type of id without context"),
-            ValueInner::I64(_) => Type::NumType(NumType::I64),
-            ValueInner::String(_) => Type::String,
-            ValueInner::Rational(_) => Type::NumType(NumType::Rational),
-            ValueInner::Unit => Type::Unit,
+    pub fn from_id(tag: Symbol, id: Id) -> Self {
+        Value {
+            tag,
+            bits: usize::from(id) as u64,
         }
     }
 }
 
-macro_rules! impl_from {
-    ($ctor:ident($t:ty)) => {
-        impl From<Value> for $t {
-            fn from(value: Value) -> Self {
-                match value.0 {
-                    ValueInner::$ctor(t) => t,
-                    _ => panic!("Expected {}, got {value:?}", stringify!($ctor)),
-                }
-            }
-        }
+// impl Display for Value {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         match &self.0 {
+//             ValueInner::Bool(b) => b.fmt(f),
+//             ValueInner::Id(id) => id.fmt(f),
+//             ValueInner::I64(i) => i.fmt(f),
+//             ValueInner::String(s) => write!(f, "\"{s}\""),
+//             ValueInner::Rational(r) => r.fmt(f),
+//             ValueInner::Unit => write!(f, "()"),
+//         }
+//     }
+// }
 
-        impl From<$t> for Value {
-            fn from(t: $t) -> Self {
-                Value(ValueInner::$ctor(t))
-            }
-        }
-    };
-}
+// impl Value {
+//     pub fn fake() -> Self {
+//         Value(ValueInner::Id(Id::fake()))
+//     }
 
-impl From<()> for Value {
-    fn from(_: ()) -> Self {
-        Value(ValueInner::Unit)
+//     pub(crate) fn to_literal(&self) -> Literal {
+//         match &self.0 {
+//             ValueInner::Bool(_) => todo!(),
+//             ValueInner::Id(_) => panic!("Id isn't a literal"),
+//             ValueInner::I64(i) => Literal::Int(*i),
+//             ValueInner::String(s) => Literal::String(*s),
+//             ValueInner::Rational(r) => Literal::Rational(r.clone()),
+//             ValueInner::Unit => Literal::Unit,
+//         }
+//     }
+
+//     pub fn get_type(&self) -> Type {
+//         match &self.0 {
+//             ValueInner::Bool(_) => todo!(),
+//             ValueInner::Id(_) => panic!("Does't know the type of id without context"),
+//             ValueInner::I64(_) => Type::NumType(NumType::I64),
+//             ValueInner::String(_) => Type::String,
+//             ValueInner::Rational(_) => Type::NumType(NumType::Rational),
+//             ValueInner::Unit => Type::Unit,
+//         }
+//     }
+// }
+
+// macro_rules! impl_from {
+//     ($ctor:ident($t:ty)) => {
+//         impl From<Value> for $t {
+//             fn from(value: Value) -> Self {
+//                 match value.0 {
+//                     ValueInner::$ctor(t) => t,
+//                     _ => panic!("Expected {}, got {value:?}", stringify!($ctor)),
+//                 }
+//             }
+//         }
+
+//         impl From<$t> for Value {
+//             fn from(t: $t) -> Self {
+//                 Value(ValueInner::$ctor(t))
+//             }
+//         }
+//     };
+// }
+
+// impl From<()> for Value {
+//     fn from(_: ()) -> Self {
+//         Value(ValueInner::Unit)
+//     }
+// }
+
+impl From<i64> for Value {
+    fn from(i: i64) -> Self {
+        Self {
+            tag: Symbol::from("i64"),
+            bits: i as u64,
+        }
     }
 }
 
-impl_from!(Id(Id));
-impl_from!(I64(i64));
-impl_from!(Bool(bool));
-impl_from!(String(Symbol));
-impl_from!(Rational(BigRational));
+impl From<Symbol> for Value {
+    fn from(s: Symbol) -> Self {
+        Self {
+            tag: Symbol::from("i64"),
+            bits: NonZeroU32::from(s).get().into(),
+        }
+    }
+}
+
+// impl_from!(Id(Id));
+// impl_from!(I64(i64));
+// impl_from!(Bool(bool));
+// impl_from!(String(Symbol));
+// impl_from!(Rational(BigRational));

--- a/tests/interval.egg
+++ b/tests/interval.egg
@@ -26,3 +26,6 @@
 
 (run 1)
 (check (= (lo e) (rational 100 1)))
+
+;; testing extraction of rationals
+(extract (lo e))

--- a/tests/interval.egg
+++ b/tests/interval.egg
@@ -1,10 +1,10 @@
 (datatype Math
-  (Num rational)
+  (Num Rational)
   (Var String)
   (Mul Math Math))
 
-(function hi (Math) rational :merge (min old new))
-(function lo (Math) rational :merge (max old new))
+(function hi (Math) Rational :merge (min old new))
+(function lo (Math) Rational :merge (max old new))
 
 (rule ((= mul (Mul a b)))
       ((set (lo mul) 
@@ -14,15 +14,15 @@
 (define x (Var "x"))
 (define e (Mul x x))
 
-(set (lo x) -10//1)
-(set (hi x)  10//1)
+(set (lo x) (rational -10 1))
+(set (hi x) (rational 10 1))
 
 (run 1)
 
-(check (= (lo e) -100//1))
+(check (= (lo e) (rational -100 1)))
 
 (rule ((= mul (Mul a a)))
       ((set (lo mul) (* (lo a) (lo a)))))
 
 (run 1)
-(check (= (lo e) 100//1))
+(check (= (lo e) (rational 100 1)))

--- a/tests/map.egg
+++ b/tests/map.egg
@@ -1,0 +1,7 @@
+(sort MyMap (Map i64 String))
+
+(define my_map1 (insert (empty) 1 "one"))
+(define my_map2 (insert my_map1 2 "two"))
+
+(check (= "one" (get my_map1 1)))
+(extract my_map2)


### PR DESCRIPTION
This gives the ability to add new sorts (and primitives) the e-graph. EqSorts (union-able sorts) are still special, but they might not have to be for long.