### PR TITLE
vars with most occurrence first for compiling GJ

### DIFF
--- a/src/gj.rs
+++ b/src/gj.rs
@@ -230,7 +230,7 @@ impl EGraph {
             assert!(!info.occurences.is_empty(), "var {} has no occurences", v);
         }
 
-        vars.sort_by(|_v1, i1, _v2, i2| i1.occurences.len().cmp(&i2.occurences.len()));
+        vars.sort_by(|_v1, i1, _v2, i2| i2.occurences.len().cmp(&i1.occurences.len()));
 
         let mut program: Vec<Instr> = vars
             .iter()


### PR DESCRIPTION
The run time of the following program is reduced from 3s to 0.2s on my laptop
```
(datatype Math
  (Var i64)
  (Add Math Math)
)

(define start (Add (Var 1) (Add (Var 2) (Add (Var 3) (Add (Var 4) 
              (Add (Var 5) (Add (Var 6) (Add (Var 7) (Var 8)))))))))

(rewrite (Add x y) (Add y x))
(rewrite (Add x (Add y z)) (Add (Add x y) z))

(run 8)

(define end (Add (Var 8) (Add (Var 7) (Add (Var 6) (Add (Var 5) 
            (Add (Var 4) (Add (Var 3) (Add (Var 2) (Var 1)))))))))
(check (= start end))
```