### PR TITLE
Precise/incremental rebuilding

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -45,7 +45,8 @@ impl EGraph {
                     return vec![];
                 }
                 assert!(func.schema.output.is_eq_sort());
-                func.nodes
+                func.data
+                    .nodes
                     .iter()
                     .filter_map(move |(inputs, output)| {
                         (output == output_value).then(|| {
@@ -118,7 +119,7 @@ impl<'a> Extractor<'a> {
             for &sym in &self.ctors {
                 let func = &self.egraph.functions[&sym];
                 if func.schema.output.is_eq_sort() {
-                    for (inputs, output) in &func.nodes {
+                    for (inputs, output) in &func.data.nodes {
                         if let Some(new_cost) = self.node_total_cost(&func.schema.input, inputs) {
                             let make_new_pair = || (new_cost, Node { sym, inputs });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,9 +670,9 @@ impl EGraph {
 
     pub fn eval_lit(&self, lit: &Literal) -> Value {
         match lit {
-            Literal::Int(i) => i.store(&*self.get_sort()).unwrap(),
-            Literal::String(s) => s.store(&*self.get_sort()).unwrap(),
-            Literal::Unit => ().store(&*self.get_sort()).unwrap(),
+            Literal::Int(i) => i.store(&self.get_sort()).unwrap(),
+            Literal::String(s) => s.store(&self.get_sort()).unwrap(),
+            Literal::Unit => ().store(&self.get_sort()).unwrap(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ type ArgPtrSet = HashSet<Rc<[Value]>>;
 
 #[derive(Default, Clone, Debug)]
 struct FunctionData {
-    nodes: HashMap<Rc<[Value]>, Value>,
+    nodes: IndexMap<Rc<[Value]>, Value>,
     index: HashMap<Id, ArgPtrSet>,
 }
 
@@ -185,7 +185,7 @@ impl Function {
     fn start_rebuild(&mut self, uf: &mut UnionFind, scratch: &mut ScratchData) {
         scratch.table.clear();
         mem::swap(&mut self.data.nodes, &mut scratch.table);
-        for (args, ret) in scratch.table.drain() {
+        for (args, ret) in scratch.table.drain(..) {
             let (args, ret, _) = self.canonicalize(uf, args, ret);
             let is_eq = self.schema.output.is_eq_sort();
             self.insert_value_maybe_unify(uf, args, |uf, prev| {
@@ -385,7 +385,7 @@ impl PrimitiveLike for SimplePrimitive {
 
 #[derive(Default)]
 struct ScratchData {
-    table: HashMap<Rc<[Value]>, Value>,
+    table: IndexMap<Rc<[Value]>, Value>,
     buckets: Vec<ArgPtrSet>,
 }
 

--- a/src/sort/i64.rs
+++ b/src/sort/i64.rs
@@ -23,6 +23,7 @@ impl Sort for I64Sort {
     }
 
     #[rustfmt::skip]
+    #[allow(clippy::unnecessary_lazy_evaluations)]
     fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
         type Opt<T=()> = Option<T>;
 


### PR DESCRIPTION
This is more or less an implementation of the algorithm described in [this gist](https://gist.github.com/ezrosent/dd6f1069d4ce9f08ef359c476a52760c). A few issues came up when I tried to port this over and get tests passing:

* The trick I described around `RawTable` by storing hashcodes in the index only doesn't handle hash collisions correctly. I think it could be extended to support collisions, but there are some subtleties there and I'd prefer to keep the implementation simple to start with. We instead store `Rc<[Value]>` in both the table and the index.
* Examples like `bdd` show how you can insert non-canonical ids into a function. By default, this breaks invariants for the index because we won't catch mentions of these old Ids (they have already been `update`d away). To get around this, we recanonicalize tuples on insertion to a function if they aren't already present.

Both of these changes make the implementation slower, and anecdotally more or less all of the tests take longer to finish with this change enabled. I'd still expect it to help with larger DBs though. If we want to push this further I think there's a long list of optimizations we could add to cut the overhead here.