### PR TITLE
Add print_size command

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -65,6 +65,7 @@ pub enum Command {
     ClearRules,
     Clear,
     Print(Symbol, usize),
+    PrintSize(Symbol),
     Input {
         name: Symbol,
         file: String,

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -54,6 +54,7 @@ Command: Command = {
     "(" "push" <UNum?> ")" => Command::Push(<>.unwrap_or(1)),
     "(" "pop" <UNum?> ")" => Command::Pop(<>.unwrap_or(1)),
     "(" "print" <sym:Ident> <n:UNum?> ")" => Command::Print(sym, n.unwrap_or(10)),
+    "(" "print-size" <sym:Ident> ")" => Command::PrintSize(sym),
     "(" "input" <name:Ident> <file:String> ")" => Command::Input { name, file },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,6 +644,11 @@ impl EGraph {
         Ok(buf)
     }
 
+    pub fn print_size(&self, sym: Symbol) -> Result<String, Error> {
+        let f = self.functions.get(&sym).ok_or(TypeError::Unbound(sym))?;
+        Ok(format!("Function {} has size {}", sym, f.nodes.len()))
+    }
+
     pub fn eval_closed_expr(&mut self, expr: &Expr) -> Result<Value, NotFoundError> {
         self.eval_expr(&Default::default(), expr)
     }
@@ -960,6 +965,7 @@ impl EGraph {
                 format!("Popped {n} levels.")
             }
             Command::Print(f, n) => self.print_function(f, n)?,
+            Command::PrintSize(f) => self.print_size(f)?,
             Command::Input { name, file } => {
                 let func = self.functions.get_mut(&name).unwrap();
                 let is_unit = func.schema.output.name().as_str() == "Unit";


### PR DESCRIPTION
print-size is a simple command that lets the user verify the program produces something reasonable without looking into the functions.