### PR TITLE
Improving rebuilding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,10 +156,7 @@ impl Function {
                         // out2.value = uf.union_values(value, out2.value);
                         out2.timestamp = out2.timestamp.max(out.timestamp);
                     })
-                    .or_insert(TupleOutput {
-                        value,
-                        timestamp,
-                    })
+                    .or_insert(TupleOutput { value, timestamp })
             };
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,6 @@ impl Function {
             assert!(out.timestamp <= timestamp);
             // let value = out.value;
             let mut new_args = args.clone();
-            let mut new_out = out.clone();
             let mut modified = false;
             for (a, ty) in new_args.iter_mut().zip(&self.schema.input) {
                 if ty.is_eq_sort() {
@@ -118,15 +117,16 @@ impl Function {
                 }
             }
             if self.schema.output.is_eq_sort() {
-                new_out.value = uf.find_mut_value(out.value);
-                if new_out.value != out.value {
+                let new_value = uf.find_mut_value(out.value);
+                if out.value != new_value {
+                    new_timestamp = timestamp;
                     modified = true;
                 }
             }
 
             if modified {
                 to_delete.push(args.clone());
-                to_add.push((new_args, new_out, new_timestamp));
+                to_add.push((new_args, out.clone(), new_timestamp));
             }
             // todo!("timestamps");
             // todo!("merge fn");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,6 @@ impl Function {
             if self.schema.output.is_eq_sort() {
                 let new_value = uf.find_mut_value(out.value);
                 if out.value != new_value {
-                    new_timestamp = timestamp;
                     modified = true;
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,8 +131,6 @@ impl Function {
             // todo!("timestamps");
             // todo!("merge fn");
         }
-        println!("to_add size: {}", to_add.len());
-        println!("node size: {}", self.nodes.len());
 
         for args in to_delete {
             self.nodes.remove(&args);


### PR DESCRIPTION
This is a low hanging fruit in improving rebuilding. Since right now the database is created afresh during each rebuilding, most time is spent on inserting tuples into a new database. However, we only need to process those that are changed.

Before:
```
Geomean egglog/souffle: 0.5349996183864182
Total egglog/souffle: 0.687601368899584
```
![plot-before](https://user-images.githubusercontent.com/13150100/198521226-3343c4ec-8574-44a7-bff7-0f07588cbe39.png)


After:
```
Geomean egglog/souffle: 0.4056677316834581
Total egglog/souffle: 0.4405201946577985
```

![plot](https://user-images.githubusercontent.com/13150100/198521244-44bed876-c7b6-422c-be51-f6b475a614bf.png)


~Also, there are still many opportunities for optimization: the rebuilding in this PR uses many small vectors. ~1/2 time of the rebuilding is spent on malloc/free.~ Not the case after using smallvecs with the latest main