### PR TITLE
Removed print to stdout except from print commands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -980,8 +980,16 @@ impl EGraph {
                 }
                 format!("Popped {n} levels.")
             }
-            Command::Print(f, n) => self.print_function(f, n)?,
-            Command::PrintSize(f) => self.print_size(f)?,
+            Command::Print(f, n) => {
+                let msg = self.print_function(f, n)?;
+                println!("{}", msg);
+                msg
+            }
+            Command::PrintSize(f) => {
+                let msg = self.print_size(f)?;
+                println!("{}", msg);
+                msg
+            }
             Command::Input { name, file } => {
                 let func = self.functions.get_mut(&name).unwrap();
                 let is_unit = func.schema.output.name().as_str() == "Unit";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,13 +411,13 @@ impl EGraph {
                 let (_t0, v0) = &values[0];
                 for (_t, v) in &values[1..] {
                     if v0 != v {
-                        println!("Check failed");
+                        log::error!("Check failed");
                         // the check failed, so print out some useful info
                         self.rebuild();
                         for (_t, value) in &values {
                             if let Some((_tag, id)) = self.value_to_id(*value) {
                                 let best = self.extract(*value).1;
-                                println!("{}: {}", id, best);
+                                log::error!("{}: {}", id, best);
                             }
                         }
                         return Err(Error::CheckError(values[0].1, *v));

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,11 +33,7 @@ fn main() {
         let mut egraph = EGraph::default();
         egraph.fact_directory = args.fact_directory.clone();
         match egraph.parse_and_run_program(&s) {
-            Ok(msgs) => {
-                for msg in msgs {
-                    println!("{}", msg);
-                }
-            }
+            Ok(_msgs) => {}
             Err(err) => {
                 log::error!("{}", err);
                 std::process::exit(1)


### PR DESCRIPTION
I don't know how IO pure run_command should be. From the perspective of building external tools that communicate to egg-smol via stdin stdout, it would probably be nice to make these errors s-expressions also.
