### PR TITLE
Very simple Repl

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
-
 use clap::Parser;
 use egg_smol::EGraph;
+use std::io::{self, BufRead};
+use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 struct Args {
@@ -21,7 +21,19 @@ fn main() {
     let args = Args::parse();
 
     if args.inputs.is_empty() {
-        eprintln!("Pass in some files as arguments");
+        let stdin = io::stdin();
+        log::info!("Welcome to Egglog!");
+        let mut egraph = EGraph::default();
+        for line in stdin.lock().lines() {
+            let line = line.unwrap_or_else(|_| panic!("Failed to read line from stdout"));
+            match egraph.parse_and_run_program(&line) {
+                Ok(_msgs) => {}
+                Err(err) => {
+                    log::error!("{}", err);
+                }
+            }
+        }
+
         std::process::exit(1)
     }
 


### PR DESCRIPTION
When no filename is given, instead of quitting, goes into a barebones repl.
This repl might be fun for users, but mainly is intended to be a way for exterior processes to communicate interactively to egglog rather than as a single batch through a file.
The repl takes each new line and parses it as a sequence of commands manipulating the egraph. Commands that span multiple lines are currently disallowed.
