### PR TITLE
Choice Domain Example

### DIFF
--- a/src/sort/string.rs
+++ b/src/sort/string.rs
@@ -24,6 +24,12 @@ impl Sort for StringSort {
         self
     }
 
+    #[rustfmt::skip]
+    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
+
+        add_primitives!(eg, "const" = |a: Symbol, _b: Symbol| -> Symbol { a });
+    }
+
     fn make_expr(&self, value: Value) -> Expr {
         assert!(value.tag == self.name);
         let sym = Symbol::from(NonZeroU32::new(value.bits as _).unwrap());

--- a/src/sort/string.rs
+++ b/src/sort/string.rs
@@ -24,12 +24,6 @@ impl Sort for StringSort {
         self
     }
 
-    #[rustfmt::skip]
-    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-
-        add_primitives!(eg, "const" = |a: Symbol, _b: Symbol| -> Symbol { a });
-    }
-
     fn make_expr(&self, value: Value) -> Expr {
         assert!(value.tag == self.name);
         let sym = Symbol::from(NonZeroU32::new(value.bits as _).unwrap());

--- a/tests/choice_domain.egg
+++ b/tests/choice_domain.egg
@@ -10,13 +10,13 @@
 (edge "L6" "L8") (edge "L8" "L2")
 
 
-(function span-tree (String) String :merge (const old new))
+(function span-tree (String) String :merge old)
 
 (set (span-tree "L1") "root")
 
 (rule ((= (span-tree v) w) (edge v u)) ((set (span-tree u) v)))
 
 (run 10)
-;(print span-tree)
+(print span-tree)
 (check (= (span-tree "L2") "L1"))
 (check (!= (span-tree "L2") "L8"))

--- a/tests/choice_domain.egg
+++ b/tests/choice_domain.egg
@@ -1,0 +1,22 @@
+; Example from https://souffle-lang.github.io/choice
+; choice-domain is a somewhat subtle construct
+; Using it in combination with other egglog features may be unsound.
+; Perhaps it needs to be in it's own strata
+
+(relation edge (String String))
+
+(edge "L1" "L2") (edge "L2" "L10") (edge "L2" "L3")
+(edge "L3" "L4") (edge "L4" "L8") (edge "L3" "L6")
+(edge "L6" "L8") (edge "L8" "L2")
+
+
+(function span-tree (String) String :merge (const old new))
+
+(set (span-tree "L1") "root")
+
+(rule ((= (span-tree v) w) (edge v u)) ((set (span-tree u) v)))
+
+(run 10)
+;(print span-tree)
+(check (= (span-tree "L2") "L1"))
+(check (!= (span-tree "L2") "L8"))


### PR DESCRIPTION
A simple example demonstrating the possibility of emulating the Souffle choice-domain feature https://souffle-lang.github.io/choice
The soundness of this representation is still up for debate.