### PR TITLE
Fix backoff and allow naive evaluation as an option

### DIFF
--- a/src/gj.rs
+++ b/src/gj.rs
@@ -399,7 +399,7 @@ impl EGraph {
         let has_atoms = !cq.query.atoms.is_empty();
 
         if has_atoms {
-            let do_seminaive = true;
+            let do_seminaive = self.seminaive;
             // for the later atoms, we consider everything
             let mut timestamp_ranges = vec![0..u32::MAX; cq.query.atoms.len()];
             for (atom_i, atom) in cq.query.atoms.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -704,6 +704,8 @@ impl EGraph {
                 );
                 rule.search_time += rule_search_time;
                 searched.push((name, all_values));
+            } else {
+                self.saturated = false;
             }
         }
         let search_elapsed = search_start.elapsed();
@@ -720,6 +722,7 @@ impl EGraph {
                 rule.times_banned += 1;
                 rule.banned_until = iteration + (ban_length << rule.times_banned);
                 log::info!("Banning rule {name} for {ban_length} iterations, matched {len} times");
+                self.saturated = false;
                 continue;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,7 @@ pub struct EGraph {
     timestamp: u32,
     pub match_limit: usize,
     pub fact_directory: Option<PathBuf>,
+    pub seminaive: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -312,6 +313,7 @@ impl Default for EGraph {
             timestamp: 0,
             saturated: false,
             fact_directory: None,
+            seminaive: true,
         };
         egraph.add_sort(UnitSort::new("Unit".into()));
         egraph.add_sort(StringSort::new("String".into()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use std::path::PathBuf;
 struct Args {
     #[clap(short = 'F', long)]
     fact_directory: Option<PathBuf>,
+    #[clap(long)]
+    naive: bool,
     inputs: Vec<PathBuf>,
 }
 
@@ -44,6 +46,7 @@ fn main() {
         });
         let mut egraph = EGraph::default();
         egraph.fact_directory = args.fact_directory.clone();
+        egraph.seminaive = !args.naive;
         match egraph.parse_and_run_program(&s) {
             Ok(_msgs) => {}
             Err(err) => {


### PR DESCRIPTION
This fixes the backoff scheduler and allows users to specify --naive to disable SN evaluation