### PR TITLE
Create public define function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1033,7 +1033,12 @@ impl EGraph {
         })
     }
 
-    pub fn define(&mut self,  name: Symbol, expr: Expr,cost: Option<usize>) -> Result<ArcSort, Error> {
+    pub fn define(
+        &mut self,
+        name: Symbol,
+        expr: Expr,
+        cost: Option<usize>,
+    ) -> Result<ArcSort, Error> {
         let (sort, value) = self.eval_expr(&expr, None, true)?;
         self.declare_function(&FunctionDecl {
             name,


### PR DESCRIPTION
This PR makes extracts defining an expression into a public function.

I am working on Python bindings for this package and wanted to expose this in Python, for example, [to recreate the `eqsat_basic` example](https://egg-smol-python.readthedocs.io/en/latest/explanation/compared_to_rust.html#low-level-bindings-api).

Alternatively, `eval_expr` and  a "get function" methods could be exposed to recreate the same logic.