### PR TITLE
Make more of the API public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1033,7 +1033,12 @@ impl EGraph {
         })
     }
 
-    pub fn define(&mut self,  name: Symbol, expr: Expr,cost: Option<usize>) -> Result<ArcSort, Error> {
+    pub fn define(
+        &mut self,
+        name: Symbol,
+        expr: Expr,
+        cost: Option<usize>,
+    ) -> Result<ArcSort, Error> {
         let (sort, value) = self.eval_expr(&expr, None, true)?;
         self.declare_function(&FunctionDecl {
             name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -550,7 +550,7 @@ impl EGraph {
         }
     }
 
-    fn print_function(&mut self, sym: Symbol, n: usize) -> Result<String, Error> {
+    pub fn print_function(&mut self, sym: Symbol, n: usize) -> Result<String, Error> {
         let f = self.functions.get(&sym).ok_or(TypeError::Unbound(sym))?;
         let schema = f.schema.clone();
         let nodes = f
@@ -948,9 +948,7 @@ impl EGraph {
                 todo!()
             }
             Command::Clear => {
-                for f in self.functions.values_mut() {
-                    f.nodes.clear();
-                }
+                self.clear();
                 "Cleared.".into()
             }
             Command::Push(n) => {
@@ -1027,6 +1025,12 @@ impl EGraph {
                 format!("Read {} facts into {name} from '{file}'.", actions.len())
             }
         })
+    }
+
+    pub fn clear(&mut self) {
+        for f in self.functions.values_mut() {
+            f.nodes.clear();
+        }
     }
 
     // Extract an expression from the current state, returning the cost, the extracted expression and some number

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1058,7 +1058,11 @@ impl EGraph {
 
     // Extract an expression from the current state, returning the cost, the extracted expression and some number
     // of other variants, if variants is not zero.
-    pub fn extract_expr(&mut self, e: Expr, variants: usize) -> Result<(usize, Expr, Vec<Expr>), Error> {
+    pub fn extract_expr(
+        &mut self,
+        e: Expr,
+        variants: usize,
+    ) -> Result<(usize, Expr, Vec<Expr>), Error> {
         self.rebuild();
         let (_t, value) = self.eval_expr(&e, None, true)?;
         let (cost, expr) = self.extract(value);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -798,7 +798,7 @@ impl EGraph {
         self.add_rule_with_name(name, rule)
     }
 
-    fn eval_actions(&mut self, actions: &[Action]) -> Result<(), Error> {
+    pub fn eval_actions(&mut self, actions: &[Action]) -> Result<(), Error> {
         let types = Default::default();
         let program = self
             .compile_actions(&types, actions)


### PR DESCRIPTION
This PR is a followup to #56, which makes more of the API public. There is now enough made public to expose all the same functionality as exposed in the text command interface through Python. The corresponding Python PR is https://github.com/metadsl/egg-smol-python/pull/4.

I opted to not expose the `Value`s to Python at all, relying on these higher-level function calls instead. I saw that there was a comment on the `Value` to make it private at some point.