### PR TITLE
Z3 as a sort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ regex = "1"
 # binary dependencies
 clap = {version = "4", features = ["derive"]}
 env_logger = "0.9"
+z3 = "0.11.2"
 
 [build-dependencies]
 lalrpop = "0.19.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,10 @@ impl Default for EGraph {
         egraph.add_sort(StringSort::new("String".into()));
         egraph.add_sort(I64Sort::new("i64".into()));
         egraph.add_sort(RationalSort::new("Rational".into()));
+        egraph.add_sort(Z3Sort::new(
+            "Z3Sort".into(),
+            StringSort::new("String".into()),
+        ));
         egraph.presorts.insert("Map".into(), MapSort::make_sort);
         egraph
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,13 +318,11 @@ impl Default for EGraph {
             seminaive: true,
         };
         egraph.add_sort(UnitSort::new("Unit".into()));
-        egraph.add_sort(StringSort::new("String".into()));
+        let string_sort = Arc::new(StringSort::new("String".into()));
+        egraph.add_arcsort(string_sort.clone());
         egraph.add_sort(I64Sort::new("i64".into()));
         egraph.add_sort(RationalSort::new("Rational".into()));
-        egraph.add_sort(Z3Sort::new(
-            "Z3Sort".into(),
-            StringSort::new("String".into()),
-        ));
+        egraph.add_sort(Z3Sort::new("Z3Sort".into(), string_sort));
         egraph.presorts.insert("Map".into(), MapSort::make_sort);
         egraph
     }

--- a/src/sort/mod.rs
+++ b/src/sort/mod.rs
@@ -13,6 +13,8 @@ mod i64;
 pub use self::i64::*;
 mod map;
 pub use map::*;
+mod z3_sort;
+pub use z3_sort::*;
 
 use crate::*;
 

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -39,6 +39,13 @@ impl IntoSort for () {
     }
 }
 
+impl FromSort for () {
+    type Sort = UnitSort;
+    fn load(_sort: &Self::Sort, value: &Value) -> Self {
+        ()
+    }
+}
+
 pub struct NotEqualPrimitive {
     unit: ArcSort,
 }

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -41,9 +41,7 @@ impl IntoSort for () {
 
 impl FromSort for () {
     type Sort = UnitSort;
-    fn load(_sort: &Self::Sort, _value: &Value) -> Self {
-        ()
-    }
+    fn load(_sort: &Self::Sort, _value: &Value) -> Self {}
 }
 
 pub struct NotEqualPrimitive {

--- a/src/sort/unit.rs
+++ b/src/sort/unit.rs
@@ -41,7 +41,7 @@ impl IntoSort for () {
 
 impl FromSort for () {
     type Sort = UnitSort;
-    fn load(_sort: &Self::Sort, value: &Value) -> Self {
+    fn load(_sort: &Self::Sort, _value: &Value) -> Self {
         ()
     }
 }

--- a/src/sort/z3_sort.rs
+++ b/src/sort/z3_sort.rs
@@ -2,43 +2,247 @@ use crate::ast::Literal;
 
 use super::*;
 
-use z3::{Config, Context};
+use std::mem;
 use std::sync::Mutex;
-use z3_sys;
-use std::os::raw::c_uint;
-use std::num::NonZeroU32;
+use z3;
 
+/*
+
+Z3Bool vs (Z3 bool) as sort. meh. Does it matter much?
+
+I can specialize Z3Sort to Z3Bool, etc so long as I use the Arc<Context>
+That is nice.
+
+*/
+
+// No. Z3Ast implements hash.
+// So I can use a regular indexset.
+
+/*
+There are a couple choices:
+1. Z3Sort<'ctx>. This was not working. There is something wrong about 'ctx which comes from the held Context anyhow.
+2. Rebuild the high level z3 bindings from z3_sys to allow for hashmap storage of asts. This will largely be highly replaicetd from what the z3 crate already does
+3. Use 'static to remove the lifetime parameter from z3::ast::Dynamic. mem::trasnmute will be needed at certain spots,
+ because the context is not static
+4. Actually have a static global Z3 context avaiable.
+5. Don't use bindings at all. Construct ast/s-expressions and call smt solver via string interface
+
+
+*/
 #[derive(Debug)]
-struct MyContext(z3_sys::Z3_context);
-
-unsafe impl Send for MyContext {}
-unsafe impl Sync for MyContext {}
-
-#[derive(Debug)]
-struct MyAst(z3_sys::Z3_ast);
-
-unsafe impl Send for MyAst {}
-unsafe impl Sync for MyAst {}
-
-#[derive(Debug)]
-pub struct Z3Bool {
+pub struct Z3Sort {
     name: Symbol,
-    ctx: Mutex<MyContext>,
-    asts: Arc<Mutex<HashMap<c_uint, MyAst>>>,
- //   asts: Arc<Mutex<HashMap<c_uint,  Arc<Mutex<z3::ast::Bool<'ctx>>>>>>,
+    ctx: Arc<z3::Context>,
+    stringsort: StringSort,
+    asts: Mutex<IndexSet<z3::ast::Dynamic<'static>>>,
 }
 
-impl Z3Bool {
-    pub fn new(name: Symbol) -> Self {
-        let cfg = unsafe {z3_sys::Z3_mk_config()};
-        Self { name,
-            ctx : Mutex::new(MyContext(unsafe{z3_sys::Z3_mk_context(cfg)})),
-            asts :  Default::default()
-         }
+unsafe impl Send for Z3Sort {}
+unsafe impl Sync for Z3Sort {}
+
+impl Z3Sort {
+    pub fn new(name: Symbol, stringsort: StringSort) -> Self {
+        let cfg = z3::Config::new();
+        Self {
+            name,
+            ctx: Arc::new(z3::Context::new(&cfg)),
+            stringsort,
+            asts: Default::default(),
+        }
     }
 }
 
-impl Sort for Z3Bool {
+struct Z3True {
+    name: Symbol,
+    sort: Arc<Z3Sort>,
+}
+
+impl PrimitiveLike for Z3True {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
+        //Some(self.sort.clone())
+        match types {
+            [] => Some(self.sort.clone()),
+            _ => None,
+        }
+    }
+
+    fn apply(&self, values: &[Value]) -> Option<Value> {
+        assert!(values.is_empty());
+        //ValueMap::default().store(&self.map)
+        let sort = self.sort.clone();
+        let ctx: &z3::Context = &sort.ctx;
+        let ctx: &'static z3::Context = unsafe { mem::transmute(ctx) };
+        let d = z3::ast::Dynamic::from(z3::ast::Bool::from_bool(ctx, true));
+        d.store(&sort)
+    }
+}
+
+//example constant
+struct Z3False {
+    name: Symbol,
+    sort: Arc<Z3Sort>,
+}
+
+impl PrimitiveLike for Z3False {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
+        //Some(self.sort.clone())
+        match types {
+            [] => Some(self.sort.clone()),
+            _ => None,
+        }
+    }
+
+    fn apply(&self, values: &[Value]) -> Option<Value> {
+        assert!(values.is_empty());
+        //ValueMap::default().store(&self.map)
+        let sort = self.sort.clone();
+        let ctx: &z3::Context = &sort.ctx;
+        let d = z3::ast::Dynamic::from(z3::ast::Bool::from_bool(
+            unsafe { mem::transmute(ctx) },
+            false,
+        ));
+        d.store(&sort)
+    }
+}
+
+// exmaple unop
+struct Z3Not {
+    name: Symbol,
+    sort: Arc<Z3Sort>,
+}
+
+impl PrimitiveLike for Z3Not {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
+        //Some(self.sort.clone())
+        match types {
+            [t] => {
+                if t.name() == "Z3Sort".into() {
+                    Some(self.sort.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn apply(&self, values: &[Value]) -> Option<Value> {
+        match values {
+            [x] => {
+                //ValueMap::default().store(&self.map)
+                let sort = &self.sort;
+                let d = z3::ast::Dynamic::load(sort, x);
+                let d: z3::ast::Dynamic = d.as_bool().unwrap().not().into();
+                d.store(sort)
+            }
+            _ => panic!("Z3-not called on wrong number of arguments"),
+        }
+    }
+}
+
+// example binop
+struct Z3And {
+    name: Symbol,
+    sort: Arc<Z3Sort>,
+}
+
+impl PrimitiveLike for Z3And {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
+        //Some(self.sort.clone())
+        match types {
+            [t, t2] => {
+                if t.name() == "Z3Sort".into() && t2.name() == "Z3Sort".into() {
+                    Some(self.sort.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn apply(&self, values: &[Value]) -> Option<Value> {
+        match values {
+            [x, y] => {
+                //ValueMap::default().store(&self.map)
+                let sort = &self.sort;
+                let x = z3::ast::Dynamic::load(sort, x).as_bool().unwrap();
+                let y = z3::ast::Dynamic::load(sort, y).as_bool().unwrap();
+                let d: z3::ast::Dynamic = (x & y).into();
+                d.store(sort)
+            }
+            _ => panic!("Z3-and called on wrong number of arguments"),
+        }
+    }
+}
+
+struct Z3Check {
+    name: Symbol,
+    sort: Arc<Z3Sort>,
+}
+
+impl PrimitiveLike for Z3Check {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn accept(&self, types: &[ArcSort]) -> Option<ArcSort> {
+        //Some(self.sort.clone())
+        match types {
+            [t] => {
+                if t.name() == "Z3Sort".into() {
+                    Some(self.sort.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn apply(&self, values: &[Value]) -> Option<Value> {
+        match values {
+            [x] => {
+                //ValueMap::default().store(&self.map)
+                let sort = &self.sort;
+                let x = z3::ast::Dynamic::load(sort, x).as_bool().unwrap();
+                let s = z3::Solver::new(&self.sort.ctx);
+                s.assert(&x);
+                let res = s.check();
+                //
+                /* */
+                let res: &str = match res {
+                    z3::SatResult::Sat => "sat",
+                    z3::SatResult::Unsat => "unsat",
+                    z3::SatResult::Unknown => "unknown",
+                };
+                let res: Symbol = res.into();
+                res.store(&self.sort.stringsort)
+                //res.to_string().store();
+                //d.store(sort)
+            }
+            _ => panic!("Z3-and called on wrong number of arguments"),
+        }
+    }
+}
+
+impl Sort for Z3Sort {
     fn name(&self) -> Symbol {
         self.name
     }
@@ -48,74 +252,52 @@ impl Sort for Z3Bool {
     }
 
     #[rustfmt::skip]
-    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
-        type Opt<T=()> = Option<T>;
-
-      //  add_primitives!(eg, "true" = |a: ()| -> z3::ast::Bool<'ctx> { z3::ast::Bool::from_bool(self.ctx, true)});
-
-     // add_primitives!(eg, "true" = |_a : ()| -> z3_sys::Z3_ast{ ||{ z3_sys::Z3_mk_true(self.lock().ctx)}});
+    fn register_primitives(self: Arc<Self>, egraph: &mut EGraph) {
+        egraph.add_primitive(Z3True {
+            name: "z3true".into(),
+            sort: self.clone(),
+        }); 
+        egraph.add_primitive(Z3False{
+            name: "z3false".into(),
+            sort: self.clone(),
+        }); 
+        egraph.add_primitive(Z3Not{
+            name: "not".into(),
+            sort: self.clone(),
+        }); 
+        egraph.add_primitive(Z3And{
+            name: "and".into(),
+            sort: self.clone(),
+        }); 
+        egraph.add_primitive(Z3Check{
+            name: "check-sat".into(),
+            sort: self,
+        }); 
+        
     }
 
     fn make_expr(&self, value: Value) -> Expr {
         assert!(value.tag == self.name);
-        let sym = Symbol::from(NonZeroU32::new(value.bits as _).unwrap());
-        Expr::Lit(Literal::String(sym))
+        let ast = z3::ast::Dynamic::load(self, &value);
+        Expr::Lit(Literal::String(ast.to_string().into()))
     }
 }
 
-
-impl IntoSort for z3_sys::Z3_ast {
-    type Sort = Z3Bool;
+impl IntoSort for z3::ast::Dynamic<'static> {
+    type Sort = Z3Sort;
     fn store(self, sort: &Self::Sort) -> Option<Value> {
+        let (i, _) = sort.asts.lock().unwrap().insert_full(self);
         Some(Value {
             tag: sort.name,
-            bits: unsafe {z3_sys::Z3_get_ast_id(&mut *sort.ctx.lock().unwrap().0, self)} as u64,
+            bits: i as u64,
         })
     }
 }
 
-impl FromSort for z3_sys::Z3_ast {
-    type Sort = Z3Bool;
-    fn load(_sort: &Self::Sort, value: &Value) -> Self {
-        value.bits as Self
+impl FromSort for z3::ast::Dynamic<'static> {
+    type Sort = Z3Sort;
+    fn load(sort: &Self::Sort, value: &Value) -> Self {
+        let i = value.bits as usize;
+        (*sort.asts.lock().unwrap().get_index(i).unwrap()).clone()
     }
 }
-
-/*
-impl<'a> IntoSort for z3::ast::Bool<'a> {
-    type Sort = Z3Bool<'a>;
-    fn store(self, sort: &Self::Sort) -> Option<Value> {
-        Some(Value {
-            tag: sort.name,
-            bits: z3_sys::Z3_get_ast_id() as u64,
-        })
-    }
-}
-
-impl<'a> FromSort for z3::ast::Bool<'a> {
-    type Sort = Z3Bool<'a>;
-    fn load(_sort: &Self::Sort, value: &Value) -> Self {
-        value.bits as Self
-    }
-}
-*/
-
-/*
-impl<'a> IntoSort for z3::ast::Bool<'a> {
-    type Sort = Z3Bool;
-    fn store(self, sort: &Self::Sort) -> Option<Value> {
-        Some(Value {
-            tag: sort.name,
-            bits: NonZeroU32::from(self.to_string()).get() as _,
-        })
-    }
-}
-*/
-/*
-impl<'a> FromSort for  z3::ast::Bool<'a>   {
-    type Sort = Z3Bool;
-    fn load(_sort: &Self::Sort, value: &Value) -> Self {
-        NonZeroU32::new(value.bits as u32).unwrap().into()
-    }
-}
-*/

--- a/src/sort/z3_sort.rs
+++ b/src/sort/z3_sort.rs
@@ -1,0 +1,121 @@
+use crate::ast::Literal;
+
+use super::*;
+
+use z3::{Config, Context};
+use std::sync::Mutex;
+use z3_sys;
+use std::os::raw::c_uint;
+use std::num::NonZeroU32;
+
+#[derive(Debug)]
+struct MyContext(z3_sys::Z3_context);
+
+unsafe impl Send for MyContext {}
+unsafe impl Sync for MyContext {}
+
+#[derive(Debug)]
+struct MyAst(z3_sys::Z3_ast);
+
+unsafe impl Send for MyAst {}
+unsafe impl Sync for MyAst {}
+
+#[derive(Debug)]
+pub struct Z3Bool {
+    name: Symbol,
+    ctx: Mutex<MyContext>,
+    asts: Arc<Mutex<HashMap<c_uint, MyAst>>>,
+ //   asts: Arc<Mutex<HashMap<c_uint,  Arc<Mutex<z3::ast::Bool<'ctx>>>>>>,
+}
+
+impl Z3Bool {
+    pub fn new(name: Symbol) -> Self {
+        let cfg = unsafe {z3_sys::Z3_mk_config()};
+        Self { name,
+            ctx : Mutex::new(MyContext(unsafe{z3_sys::Z3_mk_context(cfg)})),
+            asts :  Default::default()
+         }
+    }
+}
+
+impl Sort for Z3Bool {
+    fn name(&self) -> Symbol {
+        self.name
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static> {
+        self
+    }
+
+    #[rustfmt::skip]
+    fn register_primitives(self: Arc<Self>, eg: &mut EGraph) {
+        type Opt<T=()> = Option<T>;
+
+      //  add_primitives!(eg, "true" = |a: ()| -> z3::ast::Bool<'ctx> { z3::ast::Bool::from_bool(self.ctx, true)});
+
+     // add_primitives!(eg, "true" = |_a : ()| -> z3_sys::Z3_ast{ ||{ z3_sys::Z3_mk_true(self.lock().ctx)}});
+    }
+
+    fn make_expr(&self, value: Value) -> Expr {
+        assert!(value.tag == self.name);
+        let sym = Symbol::from(NonZeroU32::new(value.bits as _).unwrap());
+        Expr::Lit(Literal::String(sym))
+    }
+}
+
+
+impl IntoSort for z3_sys::Z3_ast {
+    type Sort = Z3Bool;
+    fn store(self, sort: &Self::Sort) -> Option<Value> {
+        Some(Value {
+            tag: sort.name,
+            bits: unsafe {z3_sys::Z3_get_ast_id(&mut *sort.ctx.lock().unwrap().0, self)} as u64,
+        })
+    }
+}
+
+impl FromSort for z3_sys::Z3_ast {
+    type Sort = Z3Bool;
+    fn load(_sort: &Self::Sort, value: &Value) -> Self {
+        value.bits as Self
+    }
+}
+
+/*
+impl<'a> IntoSort for z3::ast::Bool<'a> {
+    type Sort = Z3Bool<'a>;
+    fn store(self, sort: &Self::Sort) -> Option<Value> {
+        Some(Value {
+            tag: sort.name,
+            bits: z3_sys::Z3_get_ast_id() as u64,
+        })
+    }
+}
+
+impl<'a> FromSort for z3::ast::Bool<'a> {
+    type Sort = Z3Bool<'a>;
+    fn load(_sort: &Self::Sort, value: &Value) -> Self {
+        value.bits as Self
+    }
+}
+*/
+
+/*
+impl<'a> IntoSort for z3::ast::Bool<'a> {
+    type Sort = Z3Bool;
+    fn store(self, sort: &Self::Sort) -> Option<Value> {
+        Some(Value {
+            tag: sort.name,
+            bits: NonZeroU32::from(self.to_string()).get() as _,
+        })
+    }
+}
+*/
+/*
+impl<'a> FromSort for  z3::ast::Bool<'a>   {
+    type Sort = Z3Bool;
+    fn load(_sort: &Self::Sort, value: &Value) -> Self {
+        NonZeroU32::new(value.bits as u32).unwrap().into()
+    }
+}
+*/

--- a/src/sort/z3_sort.rs
+++ b/src/sort/z3_sort.rs
@@ -33,7 +33,7 @@ There are a couple choices:
 pub struct Z3Sort {
     name: Symbol,
     ctx: Arc<z3::Context>,
-    stringsort: StringSort,
+    stringsort: Arc<StringSort>,
     asts: Mutex<IndexSet<z3::ast::Dynamic<'static>>>,
 }
 
@@ -41,7 +41,7 @@ unsafe impl Send for Z3Sort {}
 unsafe impl Sync for Z3Sort {}
 
 impl Z3Sort {
-    pub fn new(name: Symbol, stringsort: StringSort) -> Self {
+    pub fn new(name: Symbol, stringsort: Arc<StringSort>) -> Self {
         let cfg = z3::Config::new();
         Self {
             name,
@@ -228,9 +228,9 @@ impl PrimitiveLike for Z3Check {
                 //
                 /* */
                 let res: &str = match res {
-                    z3::SatResult::Sat => "sat",
-                    z3::SatResult::Unsat => "unsat",
-                    z3::SatResult::Unknown => "unknown",
+                    z3::SatResult::Sat => "\"sat\"",
+                    z3::SatResult::Unsat => "\"unsat\"",
+                    z3::SatResult::Unknown => "\"unknown\"",
                 };
                 let res: Symbol = res.into();
                 res.store(&self.sort.stringsort)
@@ -251,29 +251,27 @@ impl Sort for Z3Sort {
         self
     }
 
-    #[rustfmt::skip]
     fn register_primitives(self: Arc<Self>, egraph: &mut EGraph) {
         egraph.add_primitive(Z3True {
             name: "z3true".into(),
             sort: self.clone(),
-        }); 
-        egraph.add_primitive(Z3False{
+        });
+        egraph.add_primitive(Z3False {
             name: "z3false".into(),
             sort: self.clone(),
-        }); 
-        egraph.add_primitive(Z3Not{
+        });
+        egraph.add_primitive(Z3Not {
             name: "not".into(),
             sort: self.clone(),
-        }); 
-        egraph.add_primitive(Z3And{
+        });
+        egraph.add_primitive(Z3And {
             name: "and".into(),
             sort: self.clone(),
-        }); 
-        egraph.add_primitive(Z3Check{
+        });
+        egraph.add_primitive(Z3Check {
             name: "check-sat".into(),
             sort: self,
-        }); 
-        
+        });
     }
 
     fn make_expr(&self, value: Value) -> Expr {

--- a/tests/z3.egg
+++ b/tests/z3.egg
@@ -1,9 +1,12 @@
 (define t (z3true))
 (define f (z3false))
 (define tandt (and t (not t)))
+(define unsat "unsat")
 (define res (check-sat tandt))
 
 (print t)
 (print f)
 (print tandt)
 (print res)
+(print unsat)
+(check (= res "unsat"))

--- a/tests/z3.egg
+++ b/tests/z3.egg
@@ -1,0 +1,9 @@
+(define t (z3true))
+(define f (z3false))
+(define tandt (and t (not t)))
+(define res (check-sat tandt))
+
+(print t)
+(print f)
+(print tandt)
+(print res)


### PR DESCRIPTION
This is an initial pass at making Z3 available from inside egglog. I thought it wise to seek comments / advice before continuing to fill it out because I had to perform violence in a couple places.
The high level z3 bindings expose a lifetime parameter that associates the datatype with the lifetime of the z3 context. I found it hard/impossible to get that to work while keeping an indexset of the z3 asts inside the Z3Sort.
There are a couple choices:
1. Trying to thread `Z3Sort<'ctx>`. This was not working. Since Z3Sort needs to hold a reference to Context, there is a circularity in the data structure.
2. Rebuild the high level z3 bindings from z3_sys to allow for hashmap storage of asts. This will largely be highly replicated from what the z3 crate already does
3. Use 'static to remove the lifetime parameter from z3::ast::Dynamic. mem::transmute will be needed at a few certain spots because the context is not actually static. I don't see how these asts could escape the lifetime of the context as used here, but this doesn't feel that good. There could also perhaps be a memory leak.
4. Actually have a static global Z3 context available something like Symbol.
5. Don't use bindings at all. Construct ast/s-expressions and call smt solver via a string interface. This has the advantage of safety, parallelism, and extending to solvers beyond z3. Replicatng an smtlib ast is tiresome though. This also may enable using  regular egglog datatypes.

Some other considerations:
1. Is it better to have a sort `Z3Sort`, `Z3Bool`, or `(Z3 bool)`. One does want to define user defined sorts in z3 eventually, which it is hard to see how that latter two could support.
2. Should one always call simplify before hashconsing the z3 expression. This may improve termination and deduplicate the database.
3. Parallelism and non blocking. check-sat calls are going to become very expensive. I note that an interesting possible capability of egglog is using eids as promises/futures from external systems.
4. I also added unsafe Sync and Send traits for the Z3Sort. I am uncertain what Z3's promises are in regards to thread safety nor how to protect it if it isn't thread safe. My understanding is that egg-smol is currently not multi-threaded.
5. z3 should be guarded under a feature at least since it will probably be too annoying to get the wasm build to work. Or perhaps some mechanism to install third party sorts without having to fork the code base.
