### PR TITLE
Expose methods for external sorts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod gj;
 pub mod sort;
 mod typecheck;
 mod unionfind;
-mod util;
+pub mod util;
 mod value;
 
 use hashbrown::hash_map::Entry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,7 @@ impl EGraph {
         panic!("Failed to lookup sort: {}", std::any::type_name::<S>());
     }
 
-    fn add_primitive(&mut self, prim: impl Into<Primitive>) {
+    pub fn add_primitive(&mut self, prim: impl Into<Primitive>) {
         let prim = prim.into();
         self.primitives.entry(prim.name()).or_default().push(prim);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ impl EGraph {
         }
     }
 
-    fn get_sort<S: Sort + Send + Sync>(&self) -> Arc<S> {
+    pub fn get_sort<S: Sort + Send + Sync>(&self) -> Arc<S> {
         for sort in self.sorts.values() {
             let sort = sort.clone().as_arc_any();
             if let Ok(sort) = Arc::downcast(sort) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,8 +10,8 @@ pub(crate) type BuildHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher
 pub(crate) type HashMap<K, V> = hashbrown::HashMap<K, V, BuildHasher>;
 pub(crate) type HashSet<K> = hashbrown::HashSet<K, BuildHasher>;
 
-pub(crate) type IndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasher>;
-pub(crate) type IndexSet<K> = indexmap::IndexSet<K, BuildHasher>;
+pub type IndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasher>;
+pub type IndexSet<K> = indexmap::IndexSet<K, BuildHasher>;
 
 pub(crate) fn concat_vecs<T>(to: &mut Vec<T>, mut from: Vec<T>) {
     if to.len() < from.len() {


### PR DESCRIPTION
I found I needed to make the following public to make this external repo able to add primitives and sorts https://github.com/philzook58/egglog-z3. Making the util crate public is optional, I could just copy out the definition of `IndexSet`.