### PR TITLE
Rename define action to let

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -130,7 +130,7 @@ impl Display for Fact {
 
 #[derive(Clone, Debug)]
 pub enum Action {
-    Define(Symbol, Expr),
+    Let(Symbol, Expr),
     Set(Symbol, Vec<Expr>, Expr),
     Delete(Symbol, Vec<Expr>),
     Union(Expr, Expr),
@@ -142,7 +142,7 @@ pub enum Action {
 impl Display for Action {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Action::Define(lhs, rhs) => write!(f, "(define {} {})", lhs, rhs),
+            Action::Let(lhs, rhs) => write!(f, "(define {} {})", lhs, rhs),
             Action::Set(lhs, args, rhs) => {
                 write!(f, "(set ({} {}) {})", lhs, ListDisplay(args, " "), rhs)
             }

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -44,7 +44,7 @@ Command: Command = {
         <conditions:(":when" <List<Fact>>)?>
     ")" => Command::Rewrite(Rewrite { lhs, rhs, conditions: conditions.unwrap_or_default() }),
     "(" "define" <name:Ident> <expr:Expr> <cost:Cost> ")" => Command::Define { name, expr, cost },
-    <NonDefineAction> => Command::Action(<>),
+    <NonLetAction> => Command::Action(<>),
     "(" "run" <UNum> ")" => Command::Run(<>),
     "(" "extract" <variants:(":variants" <UNum>)?> <e:Expr> ")" => Command::Extract { e, variants: variants.unwrap_or(0) },
     "(" "check" <Fact> ")" => Command::Check(<>),
@@ -63,7 +63,7 @@ Cost: Option<usize> = {
     => None,
 }
 
-NonDefineAction: Action = {
+NonLetAction: Action = {
     "(" "set" "(" <f: Ident> <args:Expr*> ")" <v:Expr> ")" => Action::Set ( f, args, v ),
     "(" "delete" "(" <f: Ident> <args:Expr*> ")" ")" => Action::Delete ( f, args),
     "(" "union" <e1:Expr> <e2:Expr> ")" => Action::Union(<>),
@@ -72,8 +72,8 @@ NonDefineAction: Action = {
 }
 
 Action: Action = {
-    "(" "define" <name:Ident> <expr:Expr> ")" => Action::Define(name, expr),
-    <NonDefineAction> => <>,
+    "(" "let" <name:Ident> <expr:Expr> ")" => Action::Let(name, expr),
+    <NonLetAction> => <>,
 }
 
 Name: Symbol = { "[" <Ident> "]" => <> }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -368,7 +368,7 @@ struct ActionChecker<'a> {
 impl<'a> ActionChecker<'a> {
     fn check_action(&mut self, action: &Action) -> Result<(), TypeError> {
         match action {
-            Action::Define(v, e) => {
+            Action::Let(v, e) => {
                 if self.types.contains_key(v) || self.locals.contains_key(v) {
                     return Err(TypeError::AlreadyDefined(*v));
                 }

--- a/tests/matrix.egg
+++ b/tests/matrix.egg
@@ -54,17 +54,17 @@
 
 ; demand
 (rule ((= e (MMul A B)))
-((define demand1 (ncols A))
-(define demand2 (nrows A))
-(define demand3 (ncols B))
-(define demand4 (nrows B)))
+((let demand1 (ncols A))
+(let demand2 (nrows A))
+(let demand3 (ncols B))
+(let demand4 (nrows B)))
 )
 
 (rule ((= e (Kron A B)))
-((define demand1 (ncols A))
-(define demand2 (nrows A))
-(define demand3 (ncols B))
-(define demand4 (nrows B)))
+((let demand1 (ncols A))
+(let demand2 (nrows A))
+(let demand3 (ncols B))
+(let demand4 (nrows B)))
 )
 
 


### PR DESCRIPTION
This PR renames the "define" action to "let", which makes it clearer the difference between the define command and this action (closes #67).

Even though this action now doesn't conflict in name with the "define" command, it is still not allowed at the top level of the text file, because, AFAIK, it would be a no-op there.