### PR TITLE
BiRewrite Command

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -54,6 +54,7 @@ pub enum Command {
     },
     Rule(Rule),
     Rewrite(Rewrite),
+    BiRewrite(Rewrite),
     Action(Action),
     Run(usize),
     Extract {

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -43,6 +43,9 @@ Command: Command = {
     "(" "rewrite" <lhs:Expr> <rhs:Expr>
         <conditions:(":when" <List<Fact>>)?>
     ")" => Command::Rewrite(Rewrite { lhs, rhs, conditions: conditions.unwrap_or_default() }),
+    "(" "birewrite" <lhs:Expr> <rhs:Expr>
+        <conditions:(":when" <List<Fact>>)?>
+    ")" => Command::BiRewrite(Rewrite { lhs, rhs, conditions: conditions.unwrap_or_default() }),
     "(" "define" <name:Ident> <expr:Expr> <cost:Cost> ")" => Command::Define { name, expr, cost },
     <NonLetAction> => Command::Action(<>),
     "(" "run" <UNum> ")" => Command::Run(<>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,6 +885,17 @@ impl EGraph {
                 let name = self.add_rewrite(rewrite)?;
                 format!("Declared rw {name}.")
             }
+            Command::BiRewrite(rewrite) => {
+                let rw2 = rewrite.clone();
+                let _name = self.add_rewrite(rewrite)?;
+                let rewrite = Rewrite {
+                    lhs: rw2.rhs,
+                    rhs: rw2.lhs,
+                    conditions: rw2.conditions,
+                };
+                let name = self.add_rewrite(rewrite)?;
+                format!("Declared bi-rw {name}.")
+            }
             Command::Run(limit) => {
                 if should_run {
                     let [st, at, rt] = self.run_rules(limit);

--- a/tests/birewrite.egg
+++ b/tests/birewrite.egg
@@ -1,0 +1,18 @@
+(datatype Math (Add Math Math) (Lit i64))
+
+(birewrite (Add (Add x y) z) (Add x (Add y z)))
+
+(define a (Lit 1))
+(define b (Lit 2))
+(define c (Lit 3))
+
+(define d (Lit 4))
+(define e (Lit 5))
+(define f (Lit 6))
+
+(define ex1 (Add (Add a b) c))
+(define ex2 (Add d (Add e f)))
+
+(run 10)
+(check (= ex1 (Add a (Add b c))))
+(check (= ex2 (Add (Add d e) f)))


### PR DESCRIPTION
When doing theorem proving there are equational axioms which go both ways. Copying and pasting them twice is annoying and clunky. A simple birewrite command is silly but really nice. This could possibly be subsumed by some kind of macro system