### PR TITLE
Add User Defined Stopping Condition

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -56,7 +56,10 @@ pub enum Command {
     Rewrite(Rewrite),
     BiRewrite(Rewrite),
     Action(Action),
-    Run(usize),
+    Run {
+        limit: usize,
+        until: Option<Fact>,
+    },
     Extract {
         variants: usize,
         e: Expr,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -56,10 +56,7 @@ pub enum Command {
     Rewrite(Rewrite),
     BiRewrite(Rewrite),
     Action(Action),
-    Run {
-        limit: usize,
-        until: Option<Fact>,
-    },
+    Run(RunConfig),
     Extract {
         variants: usize,
         e: Expr,
@@ -77,6 +74,12 @@ pub enum Command {
     Query(Vec<Fact>),
     Push(usize),
     Pop(usize),
+}
+
+#[derive(Clone, Debug)]
+pub struct RunConfig {
+    pub limit: usize,
+    pub until: Option<Fact>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -48,7 +48,7 @@ Command: Command = {
     ")" => Command::BiRewrite(Rewrite { lhs, rhs, conditions: conditions.unwrap_or_default() }),
     "(" "define" <name:Ident> <expr:Expr> <cost:Cost> ")" => Command::Define { name, expr, cost },
     <NonLetAction> => Command::Action(<>),
-    "(" "run" <UNum> ")" => Command::Run(<>),
+    "(" "run" <limit:UNum>  <until:(":until" <Fact>)?> ")" => Command::Run {limit, until},
     "(" "extract" <variants:(":variants" <UNum>)?> <e:Expr> ")" => Command::Extract { e, variants: variants.unwrap_or(0) },
     "(" "check" <Fact> ")" => Command::Check(<>),
     "(" "clear-rules" ")" => Command::ClearRules,
@@ -97,7 +97,7 @@ Expr: Expr = {
     <Literal> => Expr::Lit(<>),
     <Ident> => Expr::Var(<>),
     <CallExpr> => <>,
-    "(" <head:PrimitiveSymbol> <tail:(Expr)+> ")" => Expr::Call(head, tail),
+    //"(" <head:PrimitiveSymbol> <tail:(Expr)+> ")" => Expr::Call(head, tail),
 };
 
 Literal: Literal = {
@@ -126,7 +126,7 @@ Bool: bool = {
     "true" => true,
     "false" => false,
 }
-Ident: Symbol = <s:r"[[:alpha:]][\w-]*"> => s.parse().unwrap();
-PrimitiveSymbol: Symbol = <r"[-+*/!=<>&|^/%]+"> => Symbol::from(<>);
+Ident: Symbol = <s:r"([[:alpha:]][\w-]*)|([-+*/!=<>&|^/%]+)"> => s.parse().unwrap();
+//PrimitiveSymbol: Symbol = <r"[-+*/!=<>&|^/%]+"> => Symbol::from(<>);
 SymString: Symbol = <r#""[^"]*""#> => Symbol::from(<>);
 String: String = <r#""[^"]*""#> => (<>).trim_matches('"').to_owned();

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -48,7 +48,7 @@ Command: Command = {
     ")" => Command::BiRewrite(Rewrite { lhs, rhs, conditions: conditions.unwrap_or_default() }),
     "(" "define" <name:Ident> <expr:Expr> <cost:Cost> ")" => Command::Define { name, expr, cost },
     <NonLetAction> => Command::Action(<>),
-    "(" "run" <limit:UNum>  <until:(":until" <Fact>)?> ")" => Command::Run {limit, until},
+    "(" "run" <limit:UNum>  <until:(":until" <Fact>)?> ")" => Command::Run(RunConfig { limit, until }),
     "(" "extract" <variants:(":variants" <UNum>)?> <e:Expr> ")" => Command::Extract { e, variants: variants.unwrap_or(0) },
     "(" "check" <Fact> ")" => Command::Check(<>),
     "(" "clear-rules" ")" => Command::ClearRules,
@@ -97,7 +97,6 @@ Expr: Expr = {
     <Literal> => Expr::Lit(<>),
     <Ident> => Expr::Var(<>),
     <CallExpr> => <>,
-    //"(" <head:PrimitiveSymbol> <tail:(Expr)+> ")" => Expr::Call(head, tail),
 };
 
 Literal: Literal = {
@@ -127,6 +126,5 @@ Bool: bool = {
     "false" => false,
 }
 Ident: Symbol = <s:r"([[:alpha:]][\w-]*)|([-+*/!=<>&|^/%]+)"> => s.parse().unwrap();
-//PrimitiveSymbol: Symbol = <r"[-+*/!=<>&|^/%]+"> => Symbol::from(<>);
 SymString: Symbol = <r#""[^"]*""#> => Symbol::from(<>);
 String: String = <r#""[^"]*""#> => (<>).trim_matches('"').to_owned();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ impl EGraph {
         }
     }
 
-    pub fn check_fact(&mut self, fact: &Fact) -> Result<(), Error> {
+    pub fn check_fact(&mut self, fact: &Fact, log: bool) -> Result<(), Error> {
         match fact {
             Fact::Eq(exprs) => {
                 assert!(exprs.len() > 1);
@@ -417,13 +417,15 @@ impl EGraph {
                 let (_t0, v0) = &values[0];
                 for (_t, v) in &values[1..] {
                     if v0 != v {
-                        log::error!("Check failed");
-                        // the check failed, so print out some useful info
-                        self.rebuild();
-                        for (_t, value) in &values {
-                            if let Some((_tag, id)) = self.value_to_id(*value) {
-                                let best = self.extract(*value).1;
-                                log::error!("{}: {}", id, best);
+                        if log {
+                            log::error!("Check failed");
+                            // the check failed, so print out some useful info
+                            self.rebuild();
+                            for (_t, value) in &values {
+                                if let Some((_tag, id)) = self.value_to_id(*value) {
+                                    let best = self.extract(*value).1;
+                                    log::error!("{}: {}", id, best);
+                                }
                             }
                         }
                         return Err(Error::CheckError(values[0].1, *v));
@@ -620,7 +622,7 @@ impl EGraph {
         Ok(format!("Function {} has size {}", sym, f.nodes.len()))
     }
 
-    pub fn run_rules(&mut self, limit: usize) -> [Duration; 3] {
+    pub fn run_rules(&mut self, limit: usize, until: Option<&Fact>) -> [Duration; 3] {
         let mut search_time = Duration::default();
         let mut apply_time = Duration::default();
 
@@ -645,6 +647,16 @@ impl EGraph {
             if self.saturated {
                 log::info!("Breaking early at iteration {}!", i);
                 break;
+            }
+            if let Some(fact) = until {
+                if self.check_fact(fact, false).is_ok() {
+                    log::info!(
+                        "Breaking early at iteration {} because of fact {}!",
+                        i,
+                        fact
+                    );
+                    break;
+                }
             }
             if self.num_tuples() > self.node_limit {
                 log::warn!(
@@ -896,9 +908,9 @@ impl EGraph {
                 let name = self.add_rewrite(rewrite)?;
                 format!("Declared bi-rw {name}.")
             }
-            Command::Run(limit) => {
+            Command::Run { limit, until } => {
                 if should_run {
-                    let [st, at, rt] = self.run_rules(limit);
+                    let [st, at, rt] = self.run_rules(limit, until.as_ref());
                     let st = st.as_secs_f64();
                     let at = at.as_secs_f64();
                     let rt = rt.as_secs_f64();
@@ -936,7 +948,7 @@ impl EGraph {
             }
             Command::Check(fact) => {
                 if should_run {
-                    self.check_fact(&fact)?;
+                    self.check_fact(&fact, true)?;
                     "Checked.".into()
                 } else {
                     "Skipping check.".into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,7 +622,8 @@ impl EGraph {
         Ok(format!("Function {} has size {}", sym, f.nodes.len()))
     }
 
-    pub fn run_rules(&mut self, limit: usize, until: Option<&Fact>) -> [Duration; 3] {
+    pub fn run_rules(&mut self, config: &RunConfig) -> [Duration; 3] {
+        let RunConfig { limit, until } = config;
         let mut search_time = Duration::default();
         let mut apply_time = Duration::default();
 
@@ -632,7 +633,7 @@ impl EGraph {
         self.rebuild();
         let mut rebuild_time = initial_rebuild_start.elapsed();
 
-        for i in 0..limit {
+        for i in 0..*limit {
             self.saturated = true;
             let [st, at] = self.step_rules(i);
             search_time += st;
@@ -908,9 +909,10 @@ impl EGraph {
                 let name = self.add_rewrite(rewrite)?;
                 format!("Declared bi-rw {name}.")
             }
-            Command::Run { limit, until } => {
+            Command::Run(config) => {
+                let limit = config.limit;
                 if should_run {
-                    let [st, at, rt] = self.run_rules(limit, until.as_ref());
+                    let [st, at, rt] = self.run_rules(&config);
                     let st = st.as_secs_f64();
                     let at = at.as_secs_f64();
                     let rt = rt.as_secs_f64();

--- a/tests/until.egg
+++ b/tests/until.egg
@@ -1,13 +1,22 @@
-(datatype G (I) (A))
+(datatype G (I) (A) (B))
 (function * (G G) G)
 (function inv (G) G)
 (birewrite (* (* a b) c) (* a (* b c))) ; assoc
 (rewrite (* I a) a) ; idl
 (rewrite (* a I) a) ; idr
+
+; A is cyclic of period 4
 (rewrite (* A (* A (* A A))) I)
 
 (define A2 (* A A))
 (define A4 (* A2 A2))
 (define A8 (* A4 A4))
 
-(run 100 :until (= A8 I))
+; non terminating rule
+(relation allgs (G))
+(rule ((allgs x)) ((allgs (* B x))))
+(allgs A)
+
+; if you remove :until, this will take a very long time
+(run 100000 :until (= A8 I))
+(check (= A8 I))

--- a/tests/until.egg
+++ b/tests/until.egg
@@ -1,0 +1,13 @@
+(datatype G (I) (A))
+(function * (G G) G)
+(function inv (G) G)
+(birewrite (* (* a b) c) (* a (* b c))) ; assoc
+(rewrite (* I a) a) ; idl
+(rewrite (* a I) a) ; idr
+(rewrite (* A (* A (* A A))) I)
+
+(define A2 (* A A))
+(define A4 (* A2 A2))
+(define A8 (* A4 A4))
+
+(run 100 :until (= A8 I))

--- a/tests/until.egg
+++ b/tests/until.egg
@@ -1,3 +1,4 @@
+; A simple group
 (datatype G (I) (A) (B))
 (function * (G G) G)
 (function inv (G) G)
@@ -20,3 +21,7 @@
 ; if you remove :until, this will take a very long time
 (run 100000 :until (= A8 I))
 (check (= A8 I))
+(check (!= B A))
+(check (!= I A))
+; If you need multiple stop conditions, consider using a (relation relation stop (unit))
+; With rules filling it in with different stop conditions of interest.


### PR DESCRIPTION
For proving purposes, it's nice to state a condition for which you want the process to stop at rather than manually searching for a good iteration limit.
This adds an optional flag `:until (= foo bar)` to the `run` command, which uses the same logic essentially as the `check` command.
If you need more sophisticated stop conditions, consider using a `(relation relation stop (unit))` with rules filling it in with different stop conditions of interest.

I also removed some redundancy in the parser which was a holdover from when primitives were lexically different from user defined functions. Now user defined functions with operator like names are enabled. This change was orthogonal to the main point of this pull request, but I was sick of writing `mul` in my example.