### PR TITLE
Calc command

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -57,7 +57,7 @@ pub enum Command {
     BiRewrite(Rewrite),
     Action(Action),
     Run(RunConfig),
-    Calc(Vec<TypeBind>, Vec<Expr>),
+    Calc(Vec<IdentSort>, Vec<Expr>),
     Extract {
         variants: usize,
         e: Expr,
@@ -77,9 +77,15 @@ pub enum Command {
     Pop(usize),
 }
 #[derive(Clone, Debug)]
-pub struct TypeBind {
+pub struct IdentSort {
     pub ident: Symbol,
     pub sort: Symbol,
+}
+
+impl Display for IdentSort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({} {})", self.ident, self.sort)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -57,6 +57,7 @@ pub enum Command {
     BiRewrite(Rewrite),
     Action(Action),
     Run(RunConfig),
+    Calc(Vec<TypeBind>, Vec<Expr>),
     Extract {
         variants: usize,
         e: Expr,
@@ -74,6 +75,11 @@ pub enum Command {
     Query(Vec<Fact>),
     Push(usize),
     Pop(usize),
+}
+#[derive(Clone, Debug)]
+pub struct TypeBind {
+    pub ident: Symbol,
+    pub sort: Symbol,
 }
 
 #[derive(Clone, Debug)]

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -49,6 +49,7 @@ Command: Command = {
     "(" "define" <name:Ident> <expr:Expr> <cost:Cost> ")" => Command::Define { name, expr, cost },
     <NonLetAction> => Command::Action(<>),
     "(" "run" <limit:UNum>  <until:(":until" <Fact>)?> ")" => Command::Run(RunConfig { limit, until }),
+    "(" "calc" "(" <idents:TypeBind*> ")" <exprs:Expr+> ")" => Command::Calc(idents, exprs),
     "(" "extract" <variants:(":variants" <UNum>)?> <e:Expr> ")" => Command::Extract { e, variants: variants.unwrap_or(0) },
     "(" "check" <Fact> ")" => Command::Check(<>),
     "(" "clear-rules" ")" => Command::ClearRules,
@@ -117,6 +118,7 @@ Variant: Variant = {
 
 Type: Symbol = <Ident>;
 
+TypeBind: TypeBind = "(" <ident:Ident> <sort:Type> ")" => TypeBind { ident, sort };
 Num: i64 = <s:r"(-)?[0-9]+"> => s.parse().unwrap();
 UNum: usize = {
     <Num> => <>.try_into().unwrap(),

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -49,7 +49,7 @@ Command: Command = {
     "(" "define" <name:Ident> <expr:Expr> <cost:Cost> ")" => Command::Define { name, expr, cost },
     <NonLetAction> => Command::Action(<>),
     "(" "run" <limit:UNum>  <until:(":until" <Fact>)?> ")" => Command::Run(RunConfig { limit, until }),
-    "(" "calc" "(" <idents:TypeBind*> ")" <exprs:Expr+> ")" => Command::Calc(idents, exprs),
+    "(" "calc" "(" <idents:IdentSort*> ")" <exprs:Expr+> ")" => Command::Calc(idents, exprs),
     "(" "extract" <variants:(":variants" <UNum>)?> <e:Expr> ")" => Command::Extract { e, variants: variants.unwrap_or(0) },
     "(" "check" <Fact> ")" => Command::Check(<>),
     "(" "clear-rules" ")" => Command::ClearRules,
@@ -118,7 +118,7 @@ Variant: Variant = {
 
 Type: Symbol = <Ident>;
 
-TypeBind: TypeBind = "(" <ident:Ident> <sort:Type> ")" => TypeBind { ident, sort };
+IdentSort: IdentSort = "(" <ident:Ident> <sort:Type> ")" => IdentSort { ident, sort };
 Num: i64 = <s:r"(-)?[0-9]+"> => s.parse().unwrap();
 UNum: usize = {
     <Num> => <>.try_into().unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1110,25 +1110,23 @@ impl EGraph {
         }
         // Insert each expression pair and run until they match.
         for ab in exprs.windows(2) {
-            if let [a, b] = ab {
-                self.push();
-                *depth += 1;
-                self.eval_expr(a, None, true)?;
-                self.eval_expr(b, None, true)?;
-                let cond = Fact::Eq(vec![a.clone(), b.clone()]);
-                self.run_command(
-                    Command::Run(RunConfig {
-                        limit: 100000,
-                        until: Some(cond.clone()),
-                    }),
-                    true,
-                )?;
-                self.run_command(Command::Check(cond), true)?;
-                self.pop().unwrap();
-                *depth -= 1;
-            } else {
-                panic!();
-            }
+            let a = &ab[0];
+            let b = &ab[1];
+            self.push();
+            *depth += 1;
+            self.eval_expr(a, None, true)?;
+            self.eval_expr(b, None, true)?;
+            let cond = Fact::Eq(vec![a.clone(), b.clone()]);
+            self.run_command(
+                Command::Run(RunConfig {
+                    limit: 100000,
+                    until: Some(cond.clone()),
+                }),
+                true,
+            )?;
+            self.run_command(Command::Check(cond), true)?;
+            self.pop().unwrap();
+            *depth -= 1;
         }
         self.pop().unwrap();
         *depth -= 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1113,8 +1113,8 @@ impl EGraph {
             if let [a, b] = ab {
                 self.push();
                 *depth += 1;
-                self.eval_expr(&a, None, true)?;
-                self.eval_expr(&b, None, true)?;
+                self.eval_expr(a, None, true)?;
+                self.eval_expr(b, None, true)?;
                 let cond = Fact::Eq(vec![a.clone(), b.clone()]);
                 self.run_command(
                     Command::Run(RunConfig {
@@ -1137,7 +1137,9 @@ impl EGraph {
 
     // Prove a sequence of equalities universally quantified over idents
     pub fn calc(&mut self, idents: Vec<IdentSort>, exprs: Vec<Expr>) -> Result<(), Error> {
-        if exprs.len() >= 2 {
+        if exprs.len() < 2 {
+            Ok(())
+        } else {
             let mut depth = 0;
             let res = self.calc_helper(idents, exprs, &mut depth);
             if res.is_err() {
@@ -1149,8 +1151,6 @@ impl EGraph {
                 assert!(depth == 0);
             }
             res
-        } else {
-            Ok(())
         }
     }
 

--- a/tests/calc.egg
+++ b/tests/calc.egg
@@ -15,15 +15,14 @@
 (define A4 (* A2 A2))
 (define A8 (* A4 A4))
 
-; if you remove :until, this will take a very long time
+
 (calc ()
     (* A4 A4)
     (* (* A2 A2) (* A2 A2))
     (* A2 (* A2 (* A2 A2)))
 )
-; If you need multiple stop conditions, consider using a (relation relation stop (unit))
-; With rules filling it in with different stop conditions of interest.
 
+; Note that (calc ((I G) (b G)) ...) will fail because names must be unused
 (calc ((a G) (b G))
     (* (* b (* (inv a) a)) (inv b))
     (* b (inv b))

--- a/tests/calc.egg
+++ b/tests/calc.egg
@@ -1,0 +1,32 @@
+; A simple group
+(datatype G (I) (A) (B))
+(function * (G G) G)
+(function inv (G) G)
+(birewrite (* (* a b) c) (* a (* b c))) ; assoc
+(rewrite (* I a) a) ; idl
+(rewrite (* a I) a) ; idr
+(rewrite (* (inv a) a) I) ; invl
+(rewrite (* a (inv a)) I) ; invr
+
+; A is cyclic of period 4
+(rewrite (* A (* A (* A A))) I)
+
+(define A2 (* A A))
+(define A4 (* A2 A2))
+(define A8 (* A4 A4))
+
+; if you remove :until, this will take a very long time
+(calc ()
+    (* A4 A4)
+    (* (* A2 A2) (* A2 A2))
+    (* A2 (* A2 (* A2 A2)))
+)
+; If you need multiple stop conditions, consider using a (relation relation stop (unit))
+; With rules filling it in with different stop conditions of interest.
+
+(calc ((a G) (b G))
+    (* (* b (* (inv a) a)) (inv b))
+    (* b (inv b))
+    (I)
+)
+


### PR DESCRIPTION
[Dafny](http://dafny.org/dafny/DafnyRef/DafnyRef.html#sec-calc-statement) and [Lean](https://github.com/leanprover-community/leanprover-community.github.io/blob/newsite/templates/extras/calc.md) both have a notion of a calculational proof. Agda also has a style like this.
This is a proof command that allows one to break up a proof query with user given hints.
```
(calc ((a G) (b G))
    (* (* b (* (inv a) a)) (inv b))
    (* b (inv b))
    (I)
)
```
It works by 
1. pushing the egraph
2. inserting fresh constants (eids) as `a` and `b`. This is a way of asking a universally quantified question.
3. inserting pairs of subsequent entries of the calc command.
4. running until the two are found to be equal.
5. popping all of this out of the egraph

When I was trying to debug why my category theory proofs in metatheory.jl were not going through, I found an analogous command that I made there completely indispensable to manually bisect to the failure point.

It could also work in a unidirectional mode in the future by only inserting the first of the pair and seeking the second. This would also support calc in the `->` implication mode (inserting a fact and seeing when the consequent is derived).

This could possibly be a macro.

The way the universal quantification works here is a little goofy. I believe it is sound, but the way shadowing and scoping works is not typical. You may not make a previously defined name. For example, the following will error out. 
```
(calc ((I G) (b G)) ; error because I is previously defined in file
    (* (* b (* (inv a) a)) (inv b))
    (* b (inv b))
    (I)
)
```
Possibly in the future there needs to be a reserved internal namespace, or the ability to locally shadow tables.

A possible option that might be nice is an `:assert` flag that asserts the calc lemma as an axiom after it is proven.

Another proof command I'm excited for is a related lambda prolog-lite top down prover.

 The calc command is also a possible location for trivial parallelism

`declare_const` is an extremely limited form of raw make-set basically. It is relatively unproblematic compared to full make-set since the ids it makes are in correspondence with names and not currently available in rule actions. It is the analog of `declare-const` in smt and perhaps should be user exposed as such. It avoids the need to perform the following construction, which requires generating a name `temp_a` which needs to avoid clashing with user names.

```
(function temp_a () G)
(define a (temp_a))
```

