### PR TITLE
Include Command

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -75,6 +75,7 @@ pub enum Command {
     Query(Vec<Fact>),
     Push(usize),
     Pop(usize),
+    Include(String),
 }
 #[derive(Clone, Debug)]
 pub struct IdentSort {

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -60,7 +60,7 @@ Command: Command = {
     "(" "print" <sym:Ident> <n:UNum?> ")" => Command::Print(sym, n.unwrap_or(10)),
     "(" "print-size" <sym:Ident> ")" => Command::PrintSize(sym),
     "(" "input" <name:Ident> <file:String> ")" => Command::Input { name, file },
-    "(" "include" <file:String> ")" => Command::Include{ file },
+    "(" "include" <file:String> ")" => Command::Include(file),
 }
 
 Cost: Option<usize> = {

--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -60,6 +60,7 @@ Command: Command = {
     "(" "print" <sym:Ident> <n:UNum?> ")" => Command::Print(sym, n.unwrap_or(10)),
     "(" "print-size" <sym:Ident> ")" => Command::PrintSize(sym),
     "(" "input" <name:Ident> <file:String> ")" => Command::Input { name, file },
+    "(" "include" <file:String> ")" => Command::Include{ file },
 }
 
 Cost: Option<usize> = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1033,6 +1033,12 @@ impl EGraph {
                 println!("{}", msg);
                 msg
             }
+            Command::Include(file) => {
+                let s = std::fs::read_to_string(file)
+                    .unwrap_or_else(|_| panic!("Failed to read file {file}"));
+                self.parse_and_run_program(&s)?;
+                format!("Included file {file}")
+            }
             Command::Input { name, file } => {
                 let func = self.functions.get_mut(&name).unwrap();
                 let is_unit = func.schema.output.name().as_str() == "Unit";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1034,7 +1034,7 @@ impl EGraph {
                 msg
             }
             Command::Include(file) => {
-                let s = std::fs::read_to_string(file)
+                let s = std::fs::read_to_string(&file)
                     .unwrap_or_else(|_| panic!("Failed to read file {file}"));
                 self.parse_and_run_program(&s)?;
                 format!("Included file {file}")

--- a/tests/include.egg
+++ b/tests/include.egg
@@ -1,0 +1,2 @@
+(include "tests/path.egg")
+(check (path 1 3))


### PR DESCRIPTION
Include is a poor man's modules.
The include command allows at least some structuring and reuse. Combinations of including and clear-rules can be used to achieve an effect similar to rule sets. Axiom files can include from theories they refine. Diamonds will have a bad effect though.
In particular, I am using this because I'm hand writing some additional handwritten stuff to generated egglog files which keep getting regenerated as I find new problems. Currently the multiple files on the command line makes a new egraph for each, which is perhaps not what one would want in some situations.
It might be possible or wise to import files under a new namespace with structured ids. 
Z3 supports an include command, although I don't see it in the smtlib spec