### PR TITLE
Lightweight Provenance via Traces

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -187,7 +187,7 @@ impl Display for Rule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{} ==> {}",
+            "({} ==> {})",
             ListDisplay(&self.body, " "),
             ListDisplay(&self.head, " ")
         )
@@ -199,4 +199,31 @@ pub struct Rewrite {
     pub lhs: Expr,
     pub rhs: Expr,
     pub conditions: Vec<Fact>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Reason {
+    Define,
+    Declare,
+    Eval,
+    Unknown,
+    Cong(Symbol, SmallVec<[Value; 3]>),
+    Rule(Symbol),
+}
+
+impl Display for Reason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Reason::Define => write!(f, "define"),
+            Reason::Declare => write!(f, "declare"),
+            Reason::Rule(name) => write!(f, "{name}"),
+            Reason::Cong(name, args) => write!(
+                f,
+                "(cong ({name} {}))",
+                ListDisplay(args.into_iter().map(|v| v.bits), " ")
+            ),
+            Reason::Eval => write!(f, "eval"),
+            Reason::Unknown => write!(f, "unknown"),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1219,7 +1219,7 @@ impl EGraph {
             cost: None,
         })?;
         let f = self.functions.get_mut(&name).unwrap();
-        let id = self.unionfind.make_set();
+        let id = self.unionfind.make_set(&Reason::Declare);
         let value = Value::from_id(sort.name(), id);
         f.insert(ValueVec::default(), value, self.timestamp, &Reason::Declare);
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ impl Function {
                     self.updates += 1;
                     debug_assert_ne!(saved, value);
                     log::trace!(
-                        "(merge {} {} {} {} :reason {})",
+                        "(merge ({} {}) {} {} :reason {})",
                         self.decl.name,
                         ListDisplay(inputs.into_iter().map(|v| v.bits), " "),
                         saved.bits,
@@ -102,7 +102,7 @@ impl Function {
             }
             IEntry::Vacant(entry) => {
                 log::trace!(
-                    "(set {} {} {} :reason {})",
+                    "(set ({} {}) {} :reason {})",
                     self.decl.name,
                     ListDisplay(inputs.into_iter().map(|v| v.bits), " "),
                     value.bits,

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -127,7 +127,7 @@ impl<'a> Context<'a> {
 
     fn add_node(&mut self, node: ENode) -> Id {
         let entry = self.nodes.entry(node);
-        *entry.or_insert_with(|| self.unionfind.make_set())
+        *entry.or_insert_with(|| self.unionfind.make_set(&Reason::Unknown))
     }
 
     pub fn typecheck_query(&mut self, facts: &'a [Fact]) -> Result<Query, Vec<TypeError>> {
@@ -349,10 +349,10 @@ impl<'a> Context<'a> {
                         });
                     }
 
-                    (self.unionfind.make_set(), None)
+                    (self.unionfind.make_set(&Reason::Unknown), None)
                 } else {
                     self.errors.push(TypeError::Unbound(*sym));
-                    (self.unionfind.make_set(), None)
+                    (self.unionfind.make_set(&Reason::Unknown), None)
                 }
             }
         }
@@ -668,7 +668,7 @@ impl EGraph {
                                 Value::unit()
                             }
                             None if out.is_eq_sort() => {
-                                let id = self.unionfind.make_set();
+                                let id = self.unionfind.make_set(reason);
                                 let value = Value::from_id(out.name(), id);
                                 function.insert(values.into(), value, ts, reason);
                                 value

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -179,6 +179,7 @@ pub(crate) trait UnionFindLike<K: UnifyKey, V: UnifyValue> {
         let root1 = self.find_index_mut(index1);
         let root2 = self.find_index_mut(index2);
         let root = if root1 != root2 {
+            log::trace!("(union {index1} {index2} {root1} {root2})");
             self.union_roots(root1, root2)?
         } else {
             root1

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -32,8 +32,10 @@ impl<V> UnionFind<V> {
 }
 
 impl UnionFind<()> {
-    pub fn make_set(&mut self) -> Id {
-        self.make_set_with(())
+    pub fn make_set(&mut self, reason: &Reason) -> Id {
+        let id = self.make_set_with(());
+        log::trace!("(exists {id} :reason {reason}");
+        id
     }
 
     pub fn find_mut_value(&mut self, mut value: Value) -> Value {
@@ -300,7 +302,7 @@ mod tests {
 
         let mut uf = UnionFind::default();
         for _ in 0..n {
-            uf.make_set();
+            uf.make_set(&Reason::Unknown);
         }
 
         // test the initial condition of everyone in their own set

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -34,7 +34,7 @@ impl<V> UnionFind<V> {
 impl UnionFind<()> {
     pub fn make_set(&mut self, reason: &Reason) -> Id {
         let id = self.make_set_with(());
-        log::trace!("(exists {id} :reason {reason}");
+        log::trace!("(exists {id} :reason {reason})");
         id
     }
 
@@ -128,7 +128,7 @@ pub(crate) trait UnionFindLike<K: UnifyKey, V: UnifyValue> {
         self.len() == 0
     }
 
-    fn union(&mut self, query1: K, query2: K, reason: &crate::ast::Reason) -> K
+    fn union(&mut self, query1: K, query2: K, reason: &Reason) -> K
     where
         V: UnifyValue<Error = std::convert::Infallible>,
     {
@@ -175,12 +175,7 @@ pub(crate) trait UnionFindLike<K: UnifyKey, V: UnifyValue> {
     }
 
     /// Given two leader ids, unions the two eclasses making root1 the leader.
-    fn try_union(
-        &mut self,
-        query1: K,
-        query2: K,
-        reason: &crate::ast::Reason,
-    ) -> Result<K, V::Error> {
+    fn try_union(&mut self, query1: K, query2: K, reason: &Reason) -> Result<K, V::Error> {
         let index1 = self.index(query1);
         let index2 = self.index(query2);
         let root1 = self.find_index_mut(index1);


### PR DESCRIPTION
The idea here is if we make `log::trace` basically run on "mutational" (union, makeset, and insert) events with machine readable sexp output that is effectively provenance. (Summarized) Traces of any program that is performing proof search are proofs themselves. This is true of the proofs objects for SAT, SMT, MIP, prolog and datalog. The order/timestamp of the trace statements is some of the most important things when it comes to datalog proofs, which is why just online trace printing makes more sense than it does in other systems. Also, datalog never makes a false move.

Using `log::trace` is also convenient in that "proof production" is off by default 
`RUST_LOG=trace cargo run tests/calc.egg` is sufficient to make it turn on.

Nevertheless, this would still require a lot of chewing by an external program to use and it's probable that the proof information is incomplete until someone actually tries to use it. Extracting a proof object for a particular fact involves traversing the trace structure backwards in time, but with enough hints this is much easier than doing it all in the first place.

In addition, this architecture will not allow deeper introspection of proofs from within egglog itself, either for proof minimization or other reasons. It is however about the simplest thing that could be called proof objects. This will largely be subsumed probably by future additions to the system (like non-destructive inserts, etc), but it could get some proof based things moving for now. In any case more trace statements helps debuggability in my opinion.

The trace event from union basically holds the same data that would go into a proof producing union find.

Some downsides of this is that even if proof recording isn't desired, there is still a bit of extra `Reason` information flowing around that before. An earlier commit had a still useful amount of logging with less reason information. Maybe this is the way to go.

Really, to be useful, the reason information needs to be enhanced. Two obvious things are including the subst `[Value]` dictionary in the reason for a rule and nicer printing besides just raw `value.bits`. But I wanted to see what people thought.

