### PR TITLE
Combinator test

### DIFF
--- a/tests/combinators.egg
+++ b/tests/combinators.egg
@@ -1,0 +1,92 @@
+; Substitution in lambda-calculus via S/K/I combinators. Extremely slow, as
+; abstraction elimination does not pay attention to whether variables are free
+; in an expression before introducing 'S'.
+;
+; Provides an example of how to implement substitution by embedding in a
+; 'richer' data-type and then mapping back to syntax.
+
+(datatype Expr
+    (Var String :cost 100)
+    (Abs String Expr)
+    (T)
+    (F)
+    (If Expr Expr Expr)
+    (N i64)
+    (Add Expr Expr)
+    (App Expr Expr))
+
+; (\x. (if x then 0 else 1) + 2) false
+(define test
+    (App 
+        (Abs "x" (Add (If (Var "x") (N 0) (N 1)) (N 2))) F))
+
+(datatype CExpr
+    (CT)
+    (CF)
+    (CIf)
+    (CVar String :cost 10000) ; (variables that haven't been eliminated yet)
+    (CAbs String CExpr :cost 10000) ; (abstractions that haven't been eliminated yet)
+    (CN i64)
+    (CAdd)
+    (S)
+    (K)
+    (I)
+    (CApp CExpr CExpr))
+
+;;;; Conversion functions
+(function Comb (Expr) CExpr :cost 1000000)
+(function Uncomb (CExpr) Expr)    
+(rewrite (Comb (Uncomb cx)) cx)
+(rewrite (Uncomb (Comb x)) x)
+
+; Mechanical mappings back and forth.
+; Note: we avoid resugaring S/K/I
+(rule ((= x (N n))) ((set (Comb x) (CN n))))
+(rule ((= cx (CN n))) ((set (Uncomb cx) (N n))))
+(rule ((= x T)) ((set (Comb x) CT)))
+(rule ((= cx CT)) ((set (Uncomb cx) T)))
+(rule ((= x F)) ((set (Comb x) CF)))
+(rule ((= cx CF)) ((set (Uncomb cx) F)))
+
+(rule ((= x (If c t f)))
+    ((set (Comb x) (CApp (CApp (CApp CIf (Comb c)) (Comb t)) (Comb f)))))
+(rule ((= cx (CApp (CApp (CApp CIf cc) ct) cf)))
+    ((set (Uncomb cx) (If (Uncomb cc) (Uncomb ct) (Uncomb cf)))))
+
+(rule ((= x (Add l r)))
+    ((set (Comb x) (CApp (CApp CAdd (Comb l)) (Comb r)))))
+(rule ((= cx (CApp (CApp CAdd cl) cr)))
+    ((set (Uncomb cx) (Add (Uncomb cl) (Uncomb cr)))))
+(rule ((= x (App f a))) ((set (Comb x) (CApp (Comb f) (Comb a)))))
+
+(rule ((= x (Var v))) ((set (Comb x) (CVar v))))
+(rule ((= x (Abs v body))) ((set (Comb x) (CAbs v (Comb body)))))
+
+;;;; Abstraction Elimination 
+(rewrite (CAbs v (CVar v)) I)
+; Hacks, could be replaced by !free computation.
+(rewrite (CAbs v1 (CVar v2)) (CApp K (CVar v2)) 
+    :when ((!= v1 v2)))
+(rewrite (CAbs v (CN n)) (CApp K (CN n)))
+(rewrite (CAbs v CT) (CApp K CT))
+(rewrite (CAbs v CF) (CApp K CF))
+(rewrite (CAbs v CIf) (CApp K CIf))
+(rewrite (CAbs v CAdd) (CApp K CAdd))
+(rewrite (CAbs v (CApp x y)) (CApp (CApp S (CAbs v x)) (CAbs v y)))
+; eta reduce ?
+(rewrite (CAbs v (CApp K (CVar v))) K)
+
+;;;; Primitive Evaluation rules (defined on "surface syntax")
+(rewrite (If T t f) t)
+(rewrite (If F t f) f)
+(rewrite (Add (N n) (N m)) (N (+ n m)))
+
+;;;; Substitution Rules (defined on the combinator representation)
+(rewrite (CApp I cx) cx)
+(rewrite (CApp (CApp K cx) cy) cx)
+; Without demand, this can cause an explosion in DB size.
+(rewrite (CApp (CApp (CApp S cx) cy) cz) (CApp (CApp cx cz) (CApp cy cz)))
+
+(run 11)
+(extract (Comb test))
+(check (= test (N 3)))

--- a/tests/combinators.egg
+++ b/tests/combinators.egg
@@ -73,7 +73,7 @@
 (rewrite (CAbs v CIf) (CApp K CIf))
 (rewrite (CAbs v CAdd) (CApp K CAdd))
 (rewrite (CAbs v (CApp x y)) (CApp (CApp S (CAbs v x)) (CAbs v y)))
-; eta reduce ?
+; May be needed for multiple nested variables
 (rewrite (CAbs v (CApp K (CVar v))) K)
 
 ;;;; Primitive Evaluation rules (defined on "surface syntax")


### PR DESCRIPTION
Basic attempt at encoding a basic lambda calculus into S/K/I combinators. The test is structured to take a simple baseline AST with only primitive rewrites encoded on the AST. It then "mechanically" translates that AST to a richer datatype with S/K/I, implements substitution there, and then maps back to the source AST. 

A few notes:

* The two-type pattern could serve as a model for mechanically implementing substitution for a language with names without breaking other rewrites defined on the AST. Could be worth comparing with other approaches like explicit substitution that seem implementable in egg-smol.
* The classic presentation for translating a named lambda calculus involves negation ("fire this rewrite if variable x is not free in expression e"). This example hacks around it, but at the cost of performance.
* This translation produces a large number of large terms. There are lots of optimizations in the literature, and none are implemented here.