### PR TITLE
Support 1.2e10 float syntax

### DIFF
--- a/src/ast/parse.lalrpop
+++ b/src/ast/parse.lalrpop
@@ -131,7 +131,7 @@ Num: i64 = <s:r"(-)?[0-9]+"> => s.parse().unwrap();
 UNum: usize = {
     <Num> => <>.try_into().unwrap(),
 }
-F64: OrderedFloat<f64> = <s:r"(-)?[0-9]+\.[0-9]+"> => OrderedFloat::<f64>(s.parse().unwrap());
+F64: OrderedFloat<f64> = <s:r"(-)?[0-9]+\.[0-9]+(e(-)?[0-9]+)?"> => OrderedFloat::<f64>(s.parse().unwrap());
 Ident: Symbol = <s:r"([[:alpha:]][\w-]*)|([-+*/!=<>&|^/%]+)"> => s.parse().unwrap();
 SymString: Symbol = <r#"("[^"]*")+"#> => Symbol::from(<>);
 String: String = <r#"("[^"]*")+"#> => {


### PR DESCRIPTION
(define foo 1.2e-5)
[INFO ] Defined foo: F64Sort { name: "f64" }
(extract foo)
[INFO ] Extracted with cost 0: 0.000012
(define bar 1.2e20)
[INFO ] Defined bar: F64Sort { name: "f64" }
(extract bar)
[INFO ] Extracted with cost 0: 120000000000000000000
(define baz 1.23)
[INFO ] Defined baz: F64Sort { name: "f64" }
(extract baz)
[INFO ] Extracted with cost 0: 1.23