### PR TITLE
Fix typecheck bug

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,10 +5,11 @@ fn main() {
     println!("cargo:rerun-if-changed=src/ast/parse.lalrpop");
     lalrpop::process_root().unwrap();
     let mdir = std::env!("CARGO_MANIFEST_DIR");
-    generate_tests(&format!("{mdir}/tests/**/*.egg"));
+    generate_tests(&format!("{mdir}/tests/*.egg"), false);
+    generate_tests(&format!("{mdir}/tests/fail-typecheck/*.egg"), true);
 }
 
-fn generate_tests(glob: &str) {
+fn generate_tests(glob: &str, should_fail: bool) {
     let out_dir = env::var("OUT_DIR").unwrap();
     let mut out = std::fs::File::create(format!("{out_dir}/files.rs")).unwrap();
     for f in glob::glob(glob).unwrap() {
@@ -19,15 +20,20 @@ fn generate_tests(glob: &str) {
             .to_string_lossy()
             .replace(['.', '-', ' '], "_");
         // write a normal test
-        writeln!(out, "#[test] fn {name}() {{ run({:?}, false); }}", f).unwrap();
+        writeln!(
+            out,
+            "#[test] fn {name}() {{ run({:?}, false, {}); }}",
+            f, should_fail
+        )
+        .unwrap();
 
         // write a test with proofs enabled
         // TODO: re-enable herbie, unsound, and eqsolve when proof extraction is faster
         if !(name == "herbie" || name == "repro_unsound" || name == "eqsolve") {
             writeln!(
                 out,
-                "#[test] fn {name}_with_proofs() {{ run({:?}, true); }}",
-                f
+                "#[test] fn {name}_with_proofs() {{ run({:?}, true, {}); }}",
+                f, should_fail
             )
             .unwrap();
         }

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -15,7 +15,7 @@ fn make_ast_version(proof_state: &mut ProofState, expr: &NormExpr) -> Symbol {
     let NormExpr::Call(name, _) = expr;
     let types = proof_state
         .type_info
-        .typecheck_expr(proof_state.current_ctx, expr)
+        .typecheck_expr(proof_state.current_ctx, expr, true)
         .unwrap();
     Symbol::from(format!(
         "Ast{}_{}__",
@@ -28,7 +28,7 @@ fn make_rep_version(proof_state: &mut ProofState, expr: &NormExpr) -> Symbol {
     let NormExpr::Call(name, _) = expr;
     let types = proof_state
         .type_info
-        .typecheck_expr(proof_state.current_ctx, expr)
+        .typecheck_expr(proof_state.current_ctx, expr, true)
         .unwrap();
     Symbol::from(format!(
         "Rep{}_{}__",
@@ -578,7 +578,7 @@ fn instrument_rule(rule: &NormRule, rule_name: Symbol, proof_state: &mut ProofSt
 fn make_rep_function(proof_state: &mut ProofState, expr: &NormExpr) -> FunctionDecl {
     let types = proof_state
         .type_info
-        .typecheck_expr(proof_state.current_ctx, expr)
+        .typecheck_expr(proof_state.current_ctx, expr, true)
         .unwrap();
     FunctionDecl {
         name: make_rep_version(proof_state, expr),

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -325,7 +325,7 @@ impl TypeInfo {
     ) -> Result<(), TypeError> {
         match action {
             NormAction::Let(var, expr) => {
-                let expr_type = self.typecheck_expr(ctx, expr)?.output;
+                let expr_type = self.typecheck_expr(ctx, expr, true)?.output;
 
                 self.introduce_binding(ctx, *var, expr_type, is_global)?;
             }
@@ -334,10 +334,10 @@ impl TypeInfo {
                 self.introduce_binding(ctx, *var, lit_type, is_global)?;
             }
             NormAction::Delete(expr) => {
-                self.typecheck_expr(ctx, expr)?;
+                self.typecheck_expr(ctx, expr, true)?;
             }
             NormAction::Set(expr, other) => {
-                let func_type = self.typecheck_expr(ctx, expr)?.output;
+                let func_type = self.typecheck_expr(ctx, expr, true)?.output;
                 let other_type = self.lookup(ctx, *other)?;
                 if func_type.name() != other_type.name() {
                     return Err(TypeError::TypeMismatch(func_type, other_type));
@@ -362,7 +362,7 @@ impl TypeInfo {
     fn typecheck_fact(&mut self, ctx: CommandId, fact: &NormFact) -> Result<(), TypeError> {
         match fact {
             NormFact::Assign(var, expr) => {
-                let expr_type = self.typecheck_expr(ctx, expr)?;
+                let expr_type = self.typecheck_expr(ctx, expr, false)?;
                 if let Some(existing) = self
                     .local_types
                     .get_mut(&ctx)
@@ -491,6 +491,7 @@ impl TypeInfo {
         &mut self,
         ctx: CommandId,
         expr: &NormExpr,
+        expect_lookup: bool,
     ) -> Result<FuncType, TypeError> {
         match expr {
             NormExpr::Call(head, body) => {
@@ -502,7 +503,11 @@ impl TypeInfo {
                         .collect::<Result<Vec<_>, _>>()?
                 };
                 for (child_type, var) in child_types.iter().zip(body.iter()) {
-                    self.set_local_type(ctx, *var, child_type.clone())?;
+                    if expect_lookup {
+                        self.lookup(ctx, *var)?;
+                    } else {
+                        self.set_local_type(ctx, *var, child_type.clone())?;
+                    }
                 }
 
                 Ok(FuncType::new(

--- a/tests/fail-typecheck/unbound.egg
+++ b/tests/fail-typecheck/unbound.egg
@@ -1,0 +1,6 @@
+(datatype Math
+    (Add Math Math)
+    (Sub Math Math)
+)
+
+(rule ((= e (Add x y))) ((Add x i)))


### PR DESCRIPTION
Previously, unbound variables are caught by the SSA validity pass instead of the typechecker.
This is a simple fix