### PR TITLE
Fix bug in proof generation in the presence of merge functions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -46,19 +46,17 @@ fn generate_tests(file: &mut File, glob: &str) {
 
         // write a test with proofs enabled
         // TODO: re-enable herbie, unsound, and eqsolve when proof extraction is faster
-        if !(name == "herbie" || name == "repro_unsound" || name == "eqsolve") {
-            writeln!(
-                file,
-                r#" #[test] 
-                fn {name}_with_proofs() {{ 
-                    Run {{
-                        path: {f:?},
-                        should_fail: {should_fail},
-                        test_proofs: true,
-                    }}.run(); 
-                }}"#,
-            )
-            .unwrap();
-        }
+        writeln!(
+            file,
+            r#" #[test] 
+            fn {name}_with_proofs() {{ 
+                Run {{
+                    path: {f:?},
+                    should_fail: {should_fail},
+                    test_proofs: true,
+                }}.run(); 
+            }}"#,
+        )
+        .unwrap();
     }
 }

--- a/src/ast/desugar.rs
+++ b/src/ast/desugar.rs
@@ -482,7 +482,7 @@ pub(crate) fn desugar_command(
                 })));
 
                 // we need to run proof extraction rules again
-                res.push(NCommand::RunSchedule(NormSchedule::Saturate(Box::new(
+                /*res.push(NCommand::RunSchedule(NormSchedule::Saturate(Box::new(
                     NormSchedule::Run(NormRunConfig {
                         ruleset: "proof-extract__".into(),
                         limit: 1,
@@ -494,7 +494,7 @@ pub(crate) fn desugar_command(
                 res.push(NCommand::Extract {
                     variants: 0,
                     var: proofvar,
-                });
+                });*/
             }
 
             res

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1093,6 +1093,7 @@ impl EGraph {
             // Important to process each command individually
             // because push and pop create new scopes
             for processed in self.process_command(command)? {
+                println!("{}", processed);
                 let msg = self.run_command(processed.command, should_run)?;
                 log::info!("{}", msg);
                 msgs.push(msg);

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -588,7 +588,12 @@ fn make_rep_function(proof_state: &mut ProofState, expr: &NormExpr) -> FunctionD
             output: "TrmPrf__".into(),
         },
         merge: Some(Expr::Var("old".into())),
-        merge_action: merge_action(proof_state, types),
+        // Merge action is only needed if the output is not primitive
+        merge_action: if proof_state.type_info.is_primitive(types.output.name()) {
+            vec![]
+        } else {
+            merge_action(proof_state, types)
+        },
         default: None,
         cost: None,
     }

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -588,8 +588,8 @@ fn make_rep_function(proof_state: &mut ProofState, expr: &NormExpr) -> FunctionD
             output: "TrmPrf__".into(),
         },
         merge: Some(Expr::Var("old".into())),
-        // Merge action is only needed if the output is not primitive
-        merge_action: if proof_state.type_info.is_primitive(types.output.name()) {
+        // Merge action is only needed if the merge function is union
+        merge_action: if types.has_merge {
             vec![]
         } else {
             merge_action(proof_state, types)

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -4,11 +4,12 @@ use crate::{proofs::RULE_PROOF_KEYWORD, *};
 pub struct FuncType {
     pub input: Vec<ArcSort>,
     pub output: ArcSort,
+    pub has_merge: bool
 }
 
 impl FuncType {
-    pub fn new(input: Vec<ArcSort>, output: ArcSort) -> Self {
-        Self { input, output }
+    pub fn new(input: Vec<ArcSort>, output: ArcSort, has_merge: bool) -> Self {
+        Self { input, output, has_merge }
     }
 }
 
@@ -104,8 +105,8 @@ impl TypeInfo {
         Ok(())
     }
 
-    pub(crate) fn schema_to_functype(&self, schema: &Schema) -> Result<FuncType, TypeError> {
-        let input = schema
+    pub(crate) fn function_to_functype(&self, func: &FunctionDecl) -> Result<FuncType, TypeError> {
+        let input = func.schema
             .input
             .iter()
             .map(|name| {
@@ -116,12 +117,12 @@ impl TypeInfo {
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let output = if let Some(sort) = self.sorts.get(&schema.output) {
+        let output = if let Some(sort) = self.sorts.get(&func.schema.output) {
             Ok(sort.clone())
         } else {
-            Err(TypeError::Unbound(schema.output))
+            Err(TypeError::Unbound(func.schema.output))
         }?;
-        Ok(FuncType::new(input, output))
+        Ok(FuncType::new(input, output, func.merge.is_some()))
     }
 
     fn typecheck_ncommand(&mut self, command: &NCommand, id: CommandId) -> Result<(), TypeError> {
@@ -133,7 +134,7 @@ impl TypeInfo {
                 if self.primitives.contains_key(&fdecl.name) {
                     return Err(TypeError::PrimitiveAlreadyBound(fdecl.name));
                 }
-                let ftype = self.schema_to_functype(&fdecl.schema)?;
+                let ftype = self.function_to_functype(fdecl)?;
                 if self.func_types.insert(fdecl.name, ftype).is_some() {
                     return Err(TypeError::FunctionAlreadyBound(fdecl.name));
                 }
@@ -478,14 +479,14 @@ impl TypeInfo {
         _ctx: CommandId,
         sym: Symbol,
         input_types: Vec<ArcSort>,
-    ) -> Result<ArcSort, TypeError> {
+    ) -> Result<FuncType, TypeError> {
         if let Some(found) = self.func_types.get(&sym) {
-            Ok(found.output.clone())
+            Ok(found.clone())
         } else {
             if let Some(prims) = self.primitives.get(&sym) {
                 for prim in prims {
                     if let Some(return_type) = prim.accept(&input_types) {
-                        return Ok(return_type);
+                        return Ok(FuncType::new(input_types, return_type, false));
                     }
                 }
             }
@@ -520,10 +521,7 @@ impl TypeInfo {
                     }
                 }
 
-                Ok(FuncType::new(
-                    child_types.clone(),
-                    self.lookup_func(ctx, *head, child_types)?,
-                ))
+                self.lookup_func(ctx, *head, child_types)
             }
         }
     }


### PR DESCRIPTION
Before, the proof code assumed all merge functions were `union`, which is completely wrong and led to soundness and performance problems.
Luckily, solving it means we can run all the benchmarks with proofs enabled quickly!