### PR TITLE
Fix panic

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -674,9 +674,11 @@ impl EGraph {
                                 self.functions.get_mut(f).unwrap().insert(values, value, ts);
                                 value
                             }
-                            _ => return Err(Error::NotFoundError(NotFoundError(Expr::Var(
-                                format!("fake expression {f} {:?}", values).into(),
-                            )))),
+                            _ => {
+                                return Err(Error::NotFoundError(NotFoundError(Expr::Var(
+                                    format!("fake expression {f} {:?}", values).into(),
+                                ))))
+                            }
                         }
                     } else {
                         return Err(Error::NotFoundError(NotFoundError(Expr::Var(

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -674,7 +674,9 @@ impl EGraph {
                                 self.functions.get_mut(f).unwrap().insert(values, value, ts);
                                 value
                             }
-                            _ => panic!("invalid default for {:?}", function.decl.name),
+                            _ => return Err(Error::NotFoundError(NotFoundError(Expr::Var(
+                                format!("fake expression {f} {:?}", values).into(),
+                            )))),
                         }
                     } else {
                         return Err(Error::NotFoundError(NotFoundError(Expr::Var(

--- a/tests/cyk.egg
+++ b/tests/cyk.egg
@@ -61,6 +61,8 @@
 (run 100)
 
 (check (P 7 1 (NonTerm "S")))
+(fail (check (P 7 1 (NonTerm "VP"))))
+(fail (check (P 7 1 (NonTerm ""))))
 
 (extract test1)
 (print test1)
@@ -88,6 +90,7 @@
 
 (run 100)
 (check (P 5 1 (NonTerm "S")))
+(fail (check (P 5 1 (NonTerm "B"))))
 (define test2 (B 5 1 (NonTerm "S")):cost 1000)
 (extract:variants 10  test2)
 (print test2)
@@ -104,6 +107,10 @@
 
 (run 100)
 (check (P 5 1 (NonTerm "S")))
+(check (P 5 1 (NonTerm "A")))
+(fail (check (P 5 1 (NonTerm "B"))))
+(fail (check (P 5 1 (NonTerm ""))))
+(fail (check (P 5 1 (NonTerm "unrelated"))))
 (define test3 (B 5 1 (NonTerm "S")):cost 1000)
 (extract:variants 10 test3)
 (print test3) 

--- a/tests/fail_check.egg
+++ b/tests/fail_check.egg
@@ -1,0 +1,11 @@
+(function f (i64) i64 :merge (min old new))
+
+(set (f 1) 4)
+(set (f 1) 5)
+
+(check (= (f 1) 4))
+(fail (check (= (f 1) 2)))
+
+(delete (f 1))
+
+(fail (check (= (f 1) 4)))

--- a/tests/fail_check.egg
+++ b/tests/fail_check.egg
@@ -7,5 +7,17 @@
 (fail (check (= (f 1) 2)))
 
 (delete (f 1))
-
 (fail (check (= (f 1) 4)))
+
+(function g (i64 i64) i64 :merge (min old new))
+
+(set (g 1 2) 3)
+(set (g 2 3) 3)
+
+(check (= (g 1 2) (g 2 3)))
+(fail (check (!= (g 1 2) (g 2 3))))
+(fail (check (= (g 0 2) (g 2 3))))
+(check (= x (g 1 2)))
+(fail (check (= x (g 1 3))))
+(check (= x (g 1 2)) (= y (g 2 3)) (= x y))
+(fail (check (= x (g 0 0)) (= y (g 1 1)) (= x y)))

--- a/tests/fail_wrong_assertion.egg
+++ b/tests/fail_wrong_assertion.egg
@@ -1,3 +1,4 @@
+;; This test ensure check test fails for wrong assertion
 (function f (i64) i64 :merge (min old new))
 
 (set (f 1) 4)


### PR DESCRIPTION
A simple fix to issue [#123](https://github.com/mwillsey/egg-smol/issues/123) by replacing the panic with just returning an Error. Also, adding a fail_check test as the one in fixed issue [#124](https://github.com/mwillsey/egg-smol/issues/124), also adding some fail_check in cyk.egg.