### PR TITLE
Clarify error message for unioning base types

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -393,7 +393,7 @@ impl<'a> ActionChecker<'a> {
             Action::Union(a, b) => {
                 let (_, ty) = self.infer_expr(a)?;
                 if !ty.is_eq_sort() {
-                    panic!("no error for this yet")
+                    panic!("Base types cannot be unioned")
                 }
                 self.check_expr(b, ty)?;
                 self.instructions.push(Instruction::Union(2));


### PR DESCRIPTION
I am looking through to better understand the difference between setting and unioning and I thought it might be useful to clarify this error message.

According to the ["Better Together" paper](https://arxiv.org/abs/2304.04332) only user-defined sorts can be unionized, not builtin types:

> Crucially, values of user-defined sorts (as opposed to base types) can be unified by the union action.